### PR TITLE
Update nix to latest version of 22.11 channel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,7 +45,7 @@ go_dependencies()
 go_rules_dependencies()
 
 go_register_toolchains(
-    version = "1.19.3",
+    version = "1.19.5",
 )
 
 gazelle_dependencies()

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,9 @@
 let
 
   nixpkgs-tarball_22-11 = builtins.fetchTarball {
-    sha256 = "sha256:11w3wn2yjhaa5pv20gbfbirvjq6i3m7pqrq2msf0g7cv44vijwgw";
+    sha256 = "sha256:0745rigamnnzz4qf712pvjs3vz8qsg3r9g903k6m4z92yxr1w942";
     # 22.11
-    url = "https://github.com/NixOS/nixpkgs/archive/4d2b37a84fad1091b9de401eb450aae66f1a741e.tar.gz";
+    url = "https://github.com/NixOS/nixpkgs/archive/e6d5772f3515b8518d50122471381feae7cbae36.tar.gz";
   };
 
 in


### PR DESCRIPTION
We're using the release channel of 22.11 because it should be a stable
channel. There have been bug fixes and other updates since the previous
version. We update so we have the latest.

Two of the things that got updated (that are relevant to us) are:
1. We moved `bazel` from `6.0.0-pre.20220720.3` to `6.0.0`. The
    pre-released version worked, but it has some differences from what
    was released in `6.0.0`.
2. We moved `go` from `1.19.3` to `1.19.5`. We're not yet using `go`
    directly, so it's not a big deal. But it's good to note.