### PR TITLE
Fix docs "up to date" test

### DIFF
--- a/scripts/test-docs-up-to-date.sh
+++ b/scripts/test-docs-up-to-date.sh
@@ -7,15 +7,14 @@ IFS=$'\n\t'
 # We first generate new docs.
 make docs
 
-# We have to update the index (since timestamps might have changed).
-git update-index --refresh
 # We then check to see if there are any differences.
-output=$(git diff-index --exit-code --patch --stat HEAD -- docs)
-up_to_date=$?
-if test ${up_to_date} -ne 0; then
+if test -n "$(git status --porcelain -- docs)"; then
+    echo
+    echo 'Uncommitted changes:'
+    git diff -- docs
+    echo
     echo 'Docs are not up to date'
     echo 'Please run `make docs` and commit the changes'
-    echo 'Uncommitted changes:'
-    echo "${output}"
+    echo
     exit 1
 fi


### PR DESCRIPTION
Before, when we had `git update-index`, it would error out for any
changes at all. Which meant that even if you were just running `make
test` for a simple thing not related to docs, it would still error out.
We don't want this behavior.

Despite trying a bunch of different things, we couldn't figure out how
to get it to not error on this line. This seems to stem from `errexit`
being an extremely convoluted thing:
https://mywiki.wooledge.org/BashFAQ/105.

In any case, we switch around what we do so that instead of dealing with
`git update-index`, we deal with `git status` directly in the
conditional. This only works because of the complexities behind
`errexit`. So really, we need to just drop `errexit`…