### PR TITLE
Extract JSON-RPC implementation

### DIFF
--- a/lucirpc/client.go
+++ b/lucirpc/client.go
@@ -37,7 +37,7 @@ func (c *Client) GetSection(
 	}
 	responseBody, err := c.jsonRPCClientUCI.Invoke(
 		ctx,
-		humanReadableLogin,
+		humanReadableGetSection,
 		requestBody,
 	)
 	if err != nil {


### PR DESCRIPTION
We pull this stuff out so the rest is a little easier to understand.
It's very unfortunate that we even need to write this code, but the
`net/jsonrpc` package doesn't work with more than one value in
`"params"`, so here we are.