### PR TITLE
Clean up acceptance test recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install:
 
 .PHONY: start-acceptance-test-server
 start-acceptance-test-server:
-	docker compose --file $(ACCEPTANCE_TEST_DOCKER_COMPOSE_FILE) up --build --detach --remove-orphans
+	docker compose --file $(ACCEPTANCE_TEST_DOCKER_COMPOSE_FILE) up --build --remove-orphans --wait
 
 .PHONY: test
 test: build test-docs test-go

--- a/lucirpc/acceptance-test.Dockerfile
+++ b/lucirpc/acceptance-test.Dockerfile
@@ -2,6 +2,9 @@ FROM openwrtorg/rootfs:x86_64-22.03.3@sha256:bf650d3c71a5d31c51c50228c2991c6f41e
 
 RUN mkdir /var/lock
 RUN opkg update && opkg install \
+    # Install curl so we can make a healthcheck
+    # wget is installed, but it's hard to use for a health check.
+    curl \
     # Install LuCI JSON-RPC packages.
     # See https://github.com/openwrt/luci/wiki/JsonRpcHowTo#basics
     luci-compat \
@@ -12,3 +15,9 @@ RUN opkg update && opkg install \
     luci \
     luci-ssl
 RUN /etc/init.d/uhttpd restart
+
+HEALTHCHECK --interval=5s CMD curl \
+    --data '{"id": 1, "method": "login", "params": ["root", ""]}' \
+    --fail \
+    --no-progress-meter \
+    http://localhost/cgi-bin/luci/rpc/auth


### PR DESCRIPTION
We only need to start the acceptance test server when we want to run
acceptance tests. We make the dependencies reflect that.

We actually flesh out an interesting issue with this change. Before, the
acceptance test server would not be needed until after it was already
ready. This was due to other things running between the time the
acceptance test server was started and the acceptance tests actually
running. Now that we only start the acceptance test when we need it, we
can get into a situation where the acceptance tests are attempting to
run before the server is actually ready.

To address this situation, we add a `HEALTHCHECK` to the `docker`
container, and wait for it to be healthy by passing the `--wait` flag to
`docker compose`. This makes it so that initial start might take a bit
more time than before, but we won't fail the tests when we should've
waited for the acceptance test server to be ready in the first place.

To be clear, this health check business is a good thing. It might make
bringing up the acceptance test server a little slower initially, but
that cost should be cheap in CI, and almost free in development. More
importantly, it means we should have fewer transient errors from not
waiting for the server to be ready.