### PR TITLE
Install before generating docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean-acceptance-test-server:
 	docker compose --file $(ACCEPTANCE_TEST_DOCKER_COMPOSE_FILE) down --remove-orphans --rmi all --volumes
 
 .PHONY: docs
-docs:
+docs: install
 	go generate ./...
 
 .PHONY: install


### PR DESCRIPTION
Since we're developing this provider locally, we have to override the
`~/.terraformrc`. That override seems to mess up the generation of docs
so that whatever is generated comes from the locally installed provider,
not the code in the repo. To work around this, we make sure that we're
installed before we generate the docs.

Maybe there's a better way to do this, but it's not clear how to do
that. If we find a different way, we can switch to that later.