### PR TITLE
Setup releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+on:
+  push:
+    tags:
+      - v*
+
+# Releases need permissions to read and write the repository contents.
+# GitHub considers creating releases and uploading assets as writing contents.
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v19
+      - name: Import GPG
+        uses: crazy-max/ghaction-import-gpg@v5.2.0
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Test
+        run: nix-shell --run 'make release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,55 @@
+archives:
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+builds:
+  - binary: "{{ .ProjectName }}_v{{ .Version }}"
+    env:
+      # goreleaser does not work with CGO.
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    goos:
+      - darwin
+      - freebsd
+      - linux
+      - windows
+    goarch:
+      - "386"
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      - goarch: "386"
+        goos: darwin
+    ldflags:
+      - -s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+changelog:
+  skip: true
+
+checksum:
+  algorithm: sha256
+  extra_files:
+    - glob: terraform-registry-manifest.json
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+
+signs:
+  - args:
+      - --batch
+      - --detach-sign
+      - ${artifact}
+      - --local-user
+      # This comes from the GitHub Action environment
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - --output
+      - ${signature}
+    artifacts: checksum
+
+release:
+  draft: true
+  extra_files:
+    - glob: terraform-registry-manifest.json
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ docs: install
 install:
 	go install ./...
 
+.PHONY: release
+release:
+	goreleaser release --clean
+
 .PHONY: start-acceptance-test-server
 start-acceptance-test-server:
 	docker compose --file $(ACCEPTANCE_TEST_DOCKER_COMPOSE_FILE) up --build --remove-orphans --wait

--- a/shell.nix
+++ b/shell.nix
@@ -18,9 +18,11 @@ pkgs.mkShell {
     pkgs.gh
     pkgs.git
     pkgs.gnumake
+    pkgs.gnupg
     pkgs.go
     pkgs.go-tools
     pkgs.gopls
+    pkgs.goreleaser
     pkgs.nixpkgs-fmt
     pkgs.terraform
   ];

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "metadata": {
+        "protocol_versions": ["6.0"]
+    }
+}


### PR DESCRIPTION
There's a good chance we're going to have to iterate on this after we
merge it. For now, we're mostly following the tutorial:
https://developer.hashicorp.com/terraform/tutorials/providers/provider-release-publish,
but we're calling an audible on the releaser action. Since we're fully
vested in `nix`, we try to release through `nix`. But, there's no
telling whether this will work. I guess we'll see soon…