### PR TITLE
Don't worry about draft releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,7 +49,6 @@ signs:
     artifacts: checksum
 
 release:
-  draft: true
   extra_files:
     - glob: terraform-registry-manifest.json
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"


### PR DESCRIPTION
It's an extra step we don't really need to think about. A better
situation would be to have a release always ready to go and just publish
when it made sense. We'll get there eventually, but not at the moment.