### PR TITLE
Add the version to provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name openwrt
 
 const (
+	// version is set by the linker flag `-X main.version=<some-version>`.
 	version = "unknown"
 )
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt"
 )
@@ -10,9 +11,15 @@ import (
 // Provider documentation generation.
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name openwrt
 
+const (
+	version = "unknown"
+)
+
 func main() {
 	ctx := context.Background()
-	providerNew := openwrt.New
+	providerNew := func() provider.Provider {
+		return openwrt.New(version)
+	}
 	options := providerserver.ServeOpts{
 		Address: "registry.terraform.io/joneshf/openwrt",
 	}

--- a/openwrt/internal/system/system_data_source_acceptance_test.go
+++ b/openwrt/internal/system/system_data_source_acceptance_test.go
@@ -14,7 +14,7 @@ import (
 func TestSystemSystemDataSourceAcceptance(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New()),
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
 		},
 		Steps: []resource.TestStep{
 			{

--- a/openwrt/provider.go
+++ b/openwrt/provider.go
@@ -53,11 +53,14 @@ var (
 	_ provider.Provider = &openWrtProvider{}
 )
 
-func New() provider.Provider {
-	return &openWrtProvider{}
+func New(version string) provider.Provider {
+	return &openWrtProvider{
+		version: version,
+	}
 }
 
 type openWrtProvider struct {
+	version string
 }
 
 // Configure prepares an OpenWrt API client for data sources and resources.
@@ -148,6 +151,7 @@ func (p *openWrtProvider) Metadata(
 	res *provider.MetadataResponse,
 ) {
 	res.TypeName = providerTypeName
+	res.Version = p.version
 }
 
 // Resources defines the resources implemented in the provider.

--- a/openwrt/provider_acceptance_test.go
+++ b/openwrt/provider_acceptance_test.go
@@ -17,7 +17,7 @@ import (
 func TestOpenWrtProviderConfigureConnectsWithoutError(t *testing.T) {
 	// Given
 	ctx := context.Background()
-	openWrtProvider := openwrt.New()
+	openWrtProvider := openwrt.New("test")
 	schemaReq := provider.SchemaRequest{}
 	schemaRes := &provider.SchemaResponse{}
 	openWrtProvider.Schema(ctx, schemaReq, schemaRes)

--- a/openwrt/provider_test.go
+++ b/openwrt/provider_test.go
@@ -13,7 +13,7 @@ import (
 func TestOpenWrtProviderMetadataDoesNotSetVersion(t *testing.T) {
 	// Given
 	ctx := context.Background()
-	openWrtProvider := openwrt.New()
+	openWrtProvider := openwrt.New("test")
 	req := provider.MetadataRequest{}
 	res := &provider.MetadataResponse{}
 
@@ -21,13 +21,13 @@ func TestOpenWrtProviderMetadataDoesNotSetVersion(t *testing.T) {
 	openWrtProvider.Metadata(ctx, req, res)
 
 	// Then
-	assert.DeepEqual(t, res.Version, "")
+	assert.DeepEqual(t, res.Version, "test")
 }
 
 func TestOpenWrtProviderMetadataSetsTypeName(t *testing.T) {
 	// Given
 	ctx := context.Background()
-	openWrtProvider := openwrt.New()
+	openWrtProvider := openwrt.New("test")
 	req := provider.MetadataRequest{}
 	res := &provider.MetadataResponse{}
 
@@ -72,7 +72,7 @@ func TestOpenWrtProviderSchemaUsernameAttribute(t *testing.T) {
 func TestOpenWrtProviderSchemaDoesNotUseInvalidAttributes(t *testing.T) {
 	// Given
 	ctx := context.Background()
-	openWrtProvider := openwrt.New()
+	openWrtProvider := openwrt.New("test")
 	req := provider.SchemaRequest{}
 	res := &provider.SchemaResponse{}
 	openWrtProvider.Schema(ctx, req, res)
@@ -92,7 +92,7 @@ func schemaAttributeExists(
 
 		// Given
 		ctx := context.Background()
-		openWrtProvider := openwrt.New()
+		openWrtProvider := openwrt.New("test")
 		req := provider.SchemaRequest{}
 		res := &provider.SchemaResponse{}
 
@@ -113,7 +113,7 @@ func schemaAttributeIsOptional(
 
 		// Given
 		ctx := context.Background()
-		openWrtProvider := openwrt.New()
+		openWrtProvider := openwrt.New("test")
 		req := provider.SchemaRequest{}
 		res := &provider.SchemaResponse{}
 
@@ -134,7 +134,7 @@ func schemaAttributeIsSensitive(
 
 		// Given
 		ctx := context.Background()
-		openWrtProvider := openwrt.New()
+		openWrtProvider := openwrt.New("test")
 		req := provider.SchemaRequest{}
 		res := &provider.SchemaResponse{}
 


### PR DESCRIPTION
This might be the reason the provider isn't really working. Or it could
be that the version is 0.0.0. Either way, we're adding it now. This
should get altered by `goreleaser` when it runs since it passes in
linker flags to change the `main.version` value.