### PR TITLE
Extract helpers to their own package

### DIFF
--- a/openwrt/internal/lucirpcglue/client.go
+++ b/openwrt/internal/lucirpcglue/client.go
@@ -1,0 +1,25 @@
+package lucirpcglue
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
+)
+
+// NewClient attempts to construct a new [lucirpc.Client].
+// Any diagnostic information found in the process (including errors) is returned.
+func NewClient(
+	req datasource.ConfigureRequest,
+) (*lucirpc.Client, diag.Diagnostics) {
+	diagnostics := diag.Diagnostics{}
+	client, ok := req.ProviderData.(*lucirpc.Client)
+	if !ok {
+		diagnostics.AddError(
+			"OpenWrt provider not configured correctly",
+			"Expected UCI tree, but one was not provided. This is a problem with the provider implementation. Please report this to https://github.com/joneshf/terraform-provider-openwrt",
+		)
+		return nil, diagnostics
+	}
+
+	return client, diagnostics
+}

--- a/openwrt/internal/lucirpcglue/doc.go
+++ b/openwrt/internal/lucirpcglue/doc.go
@@ -1,0 +1,2 @@
+// This package contains "glue" code for working with the [lucirpc] package from Terraform.
+package lucirpcglue

--- a/openwrt/internal/lucirpcglue/metadata.go
+++ b/openwrt/internal/lucirpcglue/metadata.go
@@ -1,0 +1,42 @@
+package lucirpcglue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
+)
+
+// GetMetadataString attempts to parse the given metadata key from the section as a string.
+// Any diagnostic information found in the process (including errors) is returned.
+func GetMetadataString(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	section map[string]json.RawMessage,
+	key string,
+) (context.Context, types.String, diag.Diagnostics) {
+	diagnostics := diag.Diagnostics{}
+	result := types.StringNull()
+	raw, ok := section[key]
+	if !ok {
+		return ctx, result, diagnostics
+	}
+
+	var value string
+	err := json.Unmarshal(raw, &value)
+	if err != nil {
+		diagnostics.AddError(
+			fmt.Sprintf("unable to parse metadata: %q", key),
+			err.Error(),
+		)
+		return ctx, result, diagnostics
+	}
+
+	result = types.StringValue(value)
+	ctx = logger.SetFieldString(ctx, fullTypeName, terraformType, key, result)
+	return ctx, result, diagnostics
+}

--- a/openwrt/internal/lucirpcglue/option.go
+++ b/openwrt/internal/lucirpcglue/option.go
@@ -1,0 +1,143 @@
+package lucirpcglue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
+)
+
+// GetOptionBool attempts to parse the given option from the section as a bool.
+// Any diagnostic information found in the process (including errors) is returned.
+func GetOptionBool(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	section map[string]json.RawMessage,
+	attribute path.Path,
+	option string,
+) (context.Context, types.Bool, diag.Diagnostics) {
+	diagnostics := diag.Diagnostics{}
+	result := types.BoolNull()
+	raw, ok := section[option]
+	if !ok {
+		return ctx, result, diagnostics
+	}
+
+	// Booleans in UCI can be any number of things:
+	// - True: "1", "yes", "on", "true", "enabled"
+	// - False: "0", "no", "off", "false", "disabled"
+	// We try to parse on of these out of the string.
+	var boolish string
+	err := json.Unmarshal(raw, &boolish)
+	if err != nil {
+		diagnostics.AddAttributeError(
+			attribute,
+			fmt.Sprintf("unable to parse option: %q", option),
+			err.Error(),
+		)
+		return ctx, result, diagnostics
+	}
+
+	switch boolish {
+	case "1", "yes", "on", "true", "enabled":
+		result = types.BoolValue(true)
+
+	case "0", "no", "off", "false", "disabled":
+		result = types.BoolValue(false)
+
+	default:
+		diagnostics.AddAttributeError(
+			attribute,
+			fmt.Sprintf("Unexpected value for option: %q", option),
+			fmt.Sprintf(`expected one of "1", "yes", "on", "true", "enabled", "0", "no", "off", "false", or "disabled"; got: %q`, boolish),
+		)
+		return ctx, result, diagnostics
+	}
+
+	ctx = logger.SetFieldBool(ctx, fullTypeName, terraformType, option, result)
+	return ctx, result, diagnostics
+}
+
+// GetOptionInt64 attempts to parse the given option from the section as an int64.
+// Any diagnostic information found in the process (including errors) is returned.
+func GetOptionInt64(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	section map[string]json.RawMessage,
+	attribute path.Path,
+	option string,
+) (context.Context, types.Int64, diag.Diagnostics) {
+	diagnostics := diag.Diagnostics{}
+	result := types.Int64Null()
+	raw, ok := section[option]
+	if !ok {
+		return ctx, result, diagnostics
+	}
+
+	// Integers in UCI are stored as strtings.
+	// We have to unmarshall first, then parse the string.
+	var intish string
+	err := json.Unmarshal(raw, &intish)
+	if err != nil {
+		diagnostics.AddAttributeError(
+			attribute,
+			fmt.Sprintf("unable to parse option: %q", option),
+			err.Error(),
+		)
+		return ctx, result, diagnostics
+	}
+
+	value, err := strconv.Atoi(intish)
+	if err != nil {
+		diagnostics.AddAttributeError(
+			attribute,
+			fmt.Sprintf("unable to convert option: %q to a string", option),
+			err.Error(),
+		)
+		return ctx, result, diagnostics
+	}
+
+	result = types.Int64Value(int64(value))
+	ctx = logger.SetFieldInt64(ctx, fullTypeName, terraformType, option, result)
+	return ctx, result, diagnostics
+}
+
+// GetOptionString attempts to parse the given option from the section as a string.
+// Any diagnostic information found in the process (including errors) is returned.
+func GetOptionString(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	section map[string]json.RawMessage,
+	attribute path.Path,
+	option string,
+) (context.Context, types.String, diag.Diagnostics) {
+	diagnostics := diag.Diagnostics{}
+	result := types.StringNull()
+	raw, ok := section[option]
+	if !ok {
+		return ctx, result, diagnostics
+	}
+
+	var value string
+	err := json.Unmarshal(raw, &value)
+	if err != nil {
+		diagnostics.AddAttributeError(
+			attribute,
+			fmt.Sprintf("unable to parse option: %q", option),
+			err.Error(),
+		)
+		return ctx, result, diagnostics
+	}
+
+	result = types.StringValue(value)
+	ctx = logger.SetFieldString(ctx, fullTypeName, terraformType, option, result)
+	return ctx, result, diagnostics
+}

--- a/openwrt/internal/lucirpcglue/section.go
+++ b/openwrt/internal/lucirpcglue/section.go
@@ -1,0 +1,31 @@
+package lucirpcglue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
+)
+
+// GetMetadataString attempts to parse the given metadata key from the section.
+// Any diagnostic information found in the process (including errors) is returned.
+func GetSection(
+	ctx context.Context,
+	client lucirpc.Client,
+	config string,
+	section string,
+) (map[string]json.RawMessage, diag.Diagnostics) {
+	diagnostics := diag.Diagnostics{}
+	result, err := client.GetSection(ctx, config, section)
+	if err != nil {
+		diagnostics.AddError(
+			fmt.Sprintf("problem getting %s.%s section", config, section),
+			err.Error(),
+		)
+		return map[string]json.RawMessage{}, diagnostics
+	}
+
+	return result, diagnostics
+}


### PR DESCRIPTION
All of these helpers are more general than this one Data Source. They're
also more specific than the `lucirpc` package. So, we make a package
that sits in-between both where these helpers live.

We'll likely iterate on the name as time goes on.