### PR TITLE
Extract `system.system` model to its own file

### DIFF
--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -1,0 +1,18 @@
+package system
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type systemModel struct {
+	ConLogLevel  types.Int64  `tfsdk:"conloglevel"`
+	CronLogLevel types.Int64  `tfsdk:"cronloglevel"`
+	Description  types.String `tfsdk:"description"`
+	Hostname     types.String `tfsdk:"hostname"`
+	Id           types.String `tfsdk:"id"`
+	LogSize      types.Int64  `tfsdk:"log_size"`
+	Notes        types.String `tfsdk:"notes"`
+	Timezone     types.String `tfsdk:"timezone"`
+	TTYLogin     types.Bool   `tfsdk:"ttylogin"`
+	Zonename     types.String `tfsdk:"zonename"`
+}

--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
@@ -206,17 +205,4 @@ func (d *systemDataSource) Schema(
 		},
 		Description: "Provides system data about an OpenWrt device",
 	}
-}
-
-type systemModel struct {
-	ConLogLevel  types.Int64  `tfsdk:"conloglevel"`
-	CronLogLevel types.Int64  `tfsdk:"cronloglevel"`
-	Description  types.String `tfsdk:"description"`
-	Hostname     types.String `tfsdk:"hostname"`
-	Id           types.String `tfsdk:"id"`
-	LogSize      types.Int64  `tfsdk:"log_size"`
-	Notes        types.String `tfsdk:"notes"`
-	Timezone     types.String `tfsdk:"timezone"`
-	TTYLogin     types.Bool   `tfsdk:"ttylogin"`
-	Zonename     types.String `tfsdk:"zonename"`
 }


### PR DESCRIPTION
This model is intended to be the same between both the Data Source and
the Resource. It shouldn't live in the Data Source file. So, we put it
in its own file.