### PR TITLE
Move most system constants to `system` file

### DIFF
--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -4,6 +4,42 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+const (
+	systemConLogLevelAttribute = "conloglevel"
+	systemConLogLevelUCIOption = "conloglevel"
+
+	systemCronLogLevelAttribute = "cronloglevel"
+	systemCronLogLevelUCIOption = "cronloglevel"
+
+	systemDescriptionAttribute = "description"
+	systemDescriptionUCIOption = "description"
+
+	systemHostnameAttribute = "hostname"
+	systemHostnameUCIOption = "hostname"
+
+	systemIdAttribute  = "id"
+	systemIdUCISection = ".name"
+
+	systemLogSizeAttribute = "log_size"
+	systemLogSizeUCIOption = "log_size"
+
+	systemNotesAttribute = "notes"
+	systemNotesUCIOption = "notes"
+
+	systemTimezoneAttribute = "timezone"
+	systemTimezoneUCIOption = "timezone"
+
+	systemTTYLoginAttribute = "ttylogin"
+	systemTTYLoginUCIOption = "ttylogin"
+
+	systemTypeName   = "system_system"
+	systemUCIConfig  = "system"
+	systemUCISection = "@system[0]"
+
+	systemZonenameAttribute = "zonename"
+	systemZonenameUCIOption = "zonename"
+)
+
 type systemModel struct {
 	ConLogLevel  types.Int64  `tfsdk:"conloglevel"`
 	CronLogLevel types.Int64  `tfsdk:"cronloglevel"`

--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -14,40 +14,6 @@ import (
 
 const (
 	dataSourceTerraformType = "data_source"
-
-	systemConLogLevelAttribute = "conloglevel"
-	systemConLogLevelUCIOption = "conloglevel"
-
-	systemCronLogLevelAttribute = "cronloglevel"
-	systemCronLogLevelUCIOption = "cronloglevel"
-
-	systemDescriptionAttribute = "description"
-	systemDescriptionUCIOption = "description"
-
-	systemHostnameAttribute = "hostname"
-	systemHostnameUCIOption = "hostname"
-
-	systemIdAttribute  = "id"
-	systemIdUCISection = ".name"
-
-	systemLogSizeAttribute = "log_size"
-	systemLogSizeUCIOption = "log_size"
-
-	systemNotesAttribute = "notes"
-	systemNotesUCIOption = "notes"
-
-	systemTimezoneAttribute = "timezone"
-	systemTimezoneUCIOption = "timezone"
-
-	systemTTYLoginAttribute = "ttylogin"
-	systemTTYLoginUCIOption = "ttylogin"
-
-	systemTypeName   = "system_system"
-	systemUCIConfig  = "system"
-	systemUCISection = "@system[0]"
-
-	systemZonenameAttribute = "zonename"
-	systemZonenameUCIOption = "zonename"
 )
 
 var (


### PR DESCRIPTION
These aren't specific to the Data Source, so they don't need to live
with it. We ought to be able to use these in the Resource as well (when
it comes).