### PR TITLE
Move `system.system` read to `system` file

### DIFF
--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -1,7 +1,14 @@
 package system
 
 import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
+	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
 const (
@@ -51,4 +58,46 @@ type systemModel struct {
 	Timezone     types.String `tfsdk:"timezone"`
 	TTYLogin     types.Bool   `tfsdk:"ttylogin"`
 	Zonename     types.String `tfsdk:"zonename"`
+}
+
+func ReadModel(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	client lucirpc.Client,
+) (context.Context, systemModel, diag.Diagnostics) {
+	tflog.Info(ctx, "Reading system model")
+	var (
+		allDiagnostics diag.Diagnostics
+		model          systemModel
+	)
+
+	section, diagnostics := lucirpcglue.GetSection(ctx, client, systemUCIConfig, systemUCISection)
+	allDiagnostics.Append(diagnostics...)
+	if allDiagnostics.HasError() {
+		return ctx, model, allDiagnostics
+	}
+
+	ctx, model.ConLogLevel, diagnostics = lucirpcglue.GetOptionInt64(ctx, fullTypeName, dataSourceTerraformType, section, path.Root(systemConLogLevelAttribute), systemConLogLevelUCIOption)
+	allDiagnostics.Append(diagnostics...)
+	ctx, model.CronLogLevel, diagnostics = lucirpcglue.GetOptionInt64(ctx, fullTypeName, dataSourceTerraformType, section, path.Root(systemCronLogLevelAttribute), systemCronLogLevelUCIOption)
+	allDiagnostics.Append(diagnostics...)
+	ctx, model.Description, diagnostics = lucirpcglue.GetOptionString(ctx, fullTypeName, dataSourceTerraformType, section, path.Root(systemDescriptionAttribute), systemDescriptionUCIOption)
+	allDiagnostics.Append(diagnostics...)
+	ctx, model.Hostname, diagnostics = lucirpcglue.GetOptionString(ctx, fullTypeName, dataSourceTerraformType, section, path.Root(systemHostnameAttribute), systemHostnameUCIOption)
+	allDiagnostics.Append(diagnostics...)
+	ctx, model.LogSize, diagnostics = lucirpcglue.GetOptionInt64(ctx, fullTypeName, dataSourceTerraformType, section, path.Root(systemLogSizeAttribute), systemLogSizeUCIOption)
+	allDiagnostics.Append(diagnostics...)
+	ctx, model.Notes, diagnostics = lucirpcglue.GetOptionString(ctx, fullTypeName, dataSourceTerraformType, section, path.Root(systemNotesAttribute), systemNotesUCIOption)
+	allDiagnostics.Append(diagnostics...)
+	ctx, model.Timezone, diagnostics = lucirpcglue.GetOptionString(ctx, fullTypeName, dataSourceTerraformType, section, path.Root(systemTimezoneAttribute), systemTimezoneUCIOption)
+	allDiagnostics.Append(diagnostics...)
+	ctx, model.TTYLogin, diagnostics = lucirpcglue.GetOptionBool(ctx, fullTypeName, dataSourceTerraformType, section, path.Root(systemTTYLoginAttribute), systemTTYLoginUCIOption)
+	allDiagnostics.Append(diagnostics...)
+	ctx, model.Zonename, diagnostics = lucirpcglue.GetOptionString(ctx, fullTypeName, dataSourceTerraformType, section, path.Root(systemZonenameAttribute), systemZonenameUCIOption)
+	allDiagnostics.Append(diagnostics...)
+	ctx, model.Id, diagnostics = lucirpcglue.GetMetadataString(ctx, fullTypeName, dataSourceTerraformType, section, systemIdUCISection)
+	allDiagnostics.Append(diagnostics...)
+
+	return ctx, model, diagnostics
 }

--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -68,7 +68,6 @@ func (d *systemDataSource) Read(
 	res *datasource.ReadResponse,
 ) {
 	tflog.Info(ctx, fmt.Sprintf("Reading %s data source", d.fullTypeName))
-
 	ctx, model, diagnostics := ReadModel(
 		ctx,
 		d.fullTypeName,

--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
@@ -70,32 +69,12 @@ func (d *systemDataSource) Read(
 ) {
 	tflog.Info(ctx, fmt.Sprintf("Reading %s data source", d.fullTypeName))
 
-	section, diagnostics := lucirpcglue.GetSection(ctx, d.client, systemUCIConfig, systemUCISection)
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	var model systemModel
-	ctx, model.ConLogLevel, diagnostics = lucirpcglue.GetOptionInt64(ctx, d.fullTypeName, dataSourceTerraformType, section, path.Root(systemConLogLevelAttribute), systemConLogLevelUCIOption)
-	res.Diagnostics.Append(diagnostics...)
-	ctx, model.CronLogLevel, diagnostics = lucirpcglue.GetOptionInt64(ctx, d.fullTypeName, dataSourceTerraformType, section, path.Root(systemCronLogLevelAttribute), systemCronLogLevelUCIOption)
-	res.Diagnostics.Append(diagnostics...)
-	ctx, model.Description, diagnostics = lucirpcglue.GetOptionString(ctx, d.fullTypeName, dataSourceTerraformType, section, path.Root(systemDescriptionAttribute), systemDescriptionUCIOption)
-	res.Diagnostics.Append(diagnostics...)
-	ctx, model.Hostname, diagnostics = lucirpcglue.GetOptionString(ctx, d.fullTypeName, dataSourceTerraformType, section, path.Root(systemHostnameAttribute), systemHostnameUCIOption)
-	res.Diagnostics.Append(diagnostics...)
-	ctx, model.LogSize, diagnostics = lucirpcglue.GetOptionInt64(ctx, d.fullTypeName, dataSourceTerraformType, section, path.Root(systemLogSizeAttribute), systemLogSizeUCIOption)
-	res.Diagnostics.Append(diagnostics...)
-	ctx, model.Notes, diagnostics = lucirpcglue.GetOptionString(ctx, d.fullTypeName, dataSourceTerraformType, section, path.Root(systemNotesAttribute), systemNotesUCIOption)
-	res.Diagnostics.Append(diagnostics...)
-	ctx, model.Timezone, diagnostics = lucirpcglue.GetOptionString(ctx, d.fullTypeName, dataSourceTerraformType, section, path.Root(systemTimezoneAttribute), systemTimezoneUCIOption)
-	res.Diagnostics.Append(diagnostics...)
-	ctx, model.TTYLogin, diagnostics = lucirpcglue.GetOptionBool(ctx, d.fullTypeName, dataSourceTerraformType, section, path.Root(systemTTYLoginAttribute), systemTTYLoginUCIOption)
-	res.Diagnostics.Append(diagnostics...)
-	ctx, model.Zonename, diagnostics = lucirpcglue.GetOptionString(ctx, d.fullTypeName, dataSourceTerraformType, section, path.Root(systemZonenameAttribute), systemZonenameUCIOption)
-	res.Diagnostics.Append(diagnostics...)
-	ctx, model.Id, diagnostics = lucirpcglue.GetMetadataString(ctx, d.fullTypeName, dataSourceTerraformType, section, systemIdUCISection)
+	ctx, model, diagnostics := ReadModel(
+		ctx,
+		d.fullTypeName,
+		dataSourceTerraformType,
+		d.client,
+	)
 	res.Diagnostics.Append(diagnostics...)
 	if res.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
This logic is going to be the same for reading a Resource as it is now
for reading a Data Source. We pull it out of the Data Source-specific
file, so it's easier to see that it's more general.