### PR TITLE
Generalize creation of the `lucirpc.Client`

### DIFF
--- a/openwrt/internal/lucirpcglue/client.go
+++ b/openwrt/internal/lucirpcglue/client.go
@@ -1,15 +1,18 @@
 package lucirpcglue
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 )
 
+type ConfigureRequest struct {
+	ProviderData any
+}
+
 // NewClient attempts to construct a new [lucirpc.Client].
 // Any diagnostic information found in the process (including errors) is returned.
 func NewClient(
-	req datasource.ConfigureRequest,
+	req ConfigureRequest,
 ) (*lucirpc.Client, diag.Diagnostics) {
 	diagnostics := diag.Diagnostics{}
 	client, ok := req.ProviderData.(*lucirpc.Client)

--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -41,7 +41,7 @@ func (d *systemDataSource) Configure(
 		return
 	}
 
-	client, diagnostics := lucirpcglue.NewClient(req)
+	client, diagnostics := lucirpcglue.NewClient(lucirpcglue.ConfigureRequest(req))
 	res.Diagnostics.Append(diagnostics...)
 	if res.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
We didn't make this sufficiently agnostic when extracing this behavior
before. We rectify that mistake so we can use this for the Resource as
well as the Data Source.