### PR TITLE
Make JSON-RPC params `json.RawMessage`

### DIFF
--- a/lucirpc/client.go
+++ b/lucirpc/client.go
@@ -31,9 +31,22 @@ func (c *Client) GetSection(
 	config string,
 	section string,
 ) (map[string]json.RawMessage, error) {
+	marshalledConfig, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to serialize config %q for %s: %w", config, humanReadableGetSection, err)
+	}
+
+	marshalledSection, err := json.Marshal(section)
+	if err != nil {
+		return nil, fmt.Errorf("unable to serialize section %q for %s: %w", section, humanReadableGetSection, err)
+	}
+
 	requestBody := jsonRPCRequestBody{
 		Method: methodGetAll,
-		Params: []string{config, section},
+		Params: []json.RawMessage{
+			marshalledConfig,
+			marshalledSection,
+		},
 	}
 	responseBody, err := c.jsonRPCClientUCI.Invoke(
 		ctx,
@@ -86,9 +99,22 @@ func NewClient(
 		Scheme: scheme,
 	}
 	httpClient := &http.Client{}
+	marshalledUsername, err := json.Marshal(username)
+	if err != nil {
+		return nil, fmt.Errorf("unable to serialize username for %s: %w", humanReadableLogin, err)
+	}
+
+	marshalledPassword, err := json.Marshal(password)
+	if err != nil {
+		return nil, fmt.Errorf("unable to serialize password for %s: %w", humanReadableLogin, err)
+	}
+
 	requestBody := jsonRPCRequestBody{
 		Method: methodLogin,
-		Params: []string{username, password},
+		Params: []json.RawMessage{
+			marshalledUsername,
+			marshalledPassword,
+		},
 	}
 	jsonRPCClient := jsonRPCNewClient(
 		*httpClient,
@@ -192,8 +218,8 @@ func jsonRPCNewClient(
 }
 
 type jsonRPCRequestBody struct {
-	Method string   `json:"method"`
-	Params []string `json:"params"`
+	Method string            `json:"method"`
+	Params []json.RawMessage `json:"params"`
 }
 
 type jsonRPCResponseBody struct {


### PR DESCRIPTION
As it turns out, each one of these methods has different parameters. So,
we can't just use a string for all of them. Instead of completely losing
any type safety with `any`, we say that they all have to be
`json.RawMessage`. It's still possible to get wrong, but hopefully not
too easy.