### PR TITLE
Make "requiredness" more correct (as "existence")

### DIFF
--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -14,6 +14,11 @@ import (
 )
 
 const (
+	ReadOnly AttributeExistence = iota
+	NoValidation
+	Optional
+	Required
+
 	systemConLogLevelAttribute = "conloglevel"
 	systemConLogLevelUCIOption = "conloglevel"
 
@@ -104,6 +109,20 @@ var (
 	}
 )
 
+type AttributeExistence int
+
+func (e AttributeExistence) ToComputed() bool {
+	return e == NoValidation || e == ReadOnly
+}
+
+func (e AttributeExistence) ToOptional() bool {
+	return e == NoValidation || e == Optional
+}
+
+func (e AttributeExistence) ToRequired() bool {
+	return e == Required
+}
+
 type systemModel struct {
 	ConLogLevel  types.Int64  `tfsdk:"conloglevel"`
 	CronLogLevel types.Int64  `tfsdk:"cronloglevel"`
@@ -160,7 +179,7 @@ func ReadModel(
 }
 
 type boolSchemaAttribute struct {
-	DataSourceRequired  bool
+	DataSourceExistence AttributeExistence
 	DeprecationMessage  string
 	Description         string
 	MarkdownDescription string
@@ -170,18 +189,19 @@ type boolSchemaAttribute struct {
 
 func (a boolSchemaAttribute) ToDataSource() datasourceschema.Attribute {
 	return datasourceschema.BoolAttribute{
-		Computed:            !a.DataSourceRequired,
+		Computed:            a.DataSourceExistence.ToComputed(),
 		DeprecationMessage:  a.DeprecationMessage,
 		Description:         a.Description,
 		MarkdownDescription: a.MarkdownDescription,
-		Required:            a.DataSourceRequired,
+		Optional:            a.DataSourceExistence.ToOptional(),
+		Required:            a.DataSourceExistence.ToRequired(),
 		Sensitive:           a.Sensitive,
 		Validators:          a.Validators,
 	}
 }
 
 type int64SchemaAttribute struct {
-	DataSourceRequired  bool
+	DataSourceExistence AttributeExistence
 	DeprecationMessage  string
 	Description         string
 	MarkdownDescription string
@@ -191,11 +211,12 @@ type int64SchemaAttribute struct {
 
 func (a int64SchemaAttribute) ToDataSource() datasourceschema.Attribute {
 	return datasourceschema.Int64Attribute{
-		Computed:            !a.DataSourceRequired,
+		Computed:            a.DataSourceExistence.ToComputed(),
 		DeprecationMessage:  a.DeprecationMessage,
 		Description:         a.Description,
 		MarkdownDescription: a.MarkdownDescription,
-		Required:            a.DataSourceRequired,
+		Optional:            a.DataSourceExistence.ToOptional(),
+		Required:            a.DataSourceExistence.ToRequired(),
 		Sensitive:           a.Sensitive,
 		Validators:          a.Validators,
 	}
@@ -206,7 +227,7 @@ type schemaAttribute interface {
 }
 
 type stringSchemaAttribute struct {
-	DataSourceRequired  bool
+	DataSourceExistence AttributeExistence
 	DeprecationMessage  string
 	Description         string
 	MarkdownDescription string
@@ -216,11 +237,12 @@ type stringSchemaAttribute struct {
 
 func (a stringSchemaAttribute) ToDataSource() datasourceschema.Attribute {
 	return datasourceschema.StringAttribute{
-		Computed:            !a.DataSourceRequired,
+		Computed:            a.DataSourceExistence.ToComputed(),
 		DeprecationMessage:  a.DeprecationMessage,
 		Description:         a.Description,
 		MarkdownDescription: a.MarkdownDescription,
-		Required:            a.DataSourceRequired,
+		Optional:            a.DataSourceExistence.ToOptional(),
+		Required:            a.DataSourceExistence.ToRequired(),
 		Sensitive:           a.Sensitive,
 		Validators:          a.Validators,
 	}


### PR DESCRIPTION
The Terraform framework does the incorrect thing here and attempts to
represent the four possibilities for requiredness as three `bool`s.
This isn't right because four out of the eight possible combinations are
invalid.  E.g. It errors somewhere if all three `bool`s are `false`, or
if required and something else are `true`.

Instead of inheriting that incorrect behavior, we make our lives simpler
by creating an "enum" of the four possible values. This "enum" is then
used to convert into that invalid representation that Terraform wants.
This way, we have a bit more confidence that we're doing the right
thing.

In trying to figure out what the name of this "enum" is, it seems like
we're more defining how the attribute exists rather than whether or not
it's required. We choose to go with a term that includes "existence."

The word "enum" is used because what we have is an approximation of a
real enum. But, this is an idiomatic pattern in go. Maybe one day we'll
get real support for enums and can have certainty that things won't go
wrong.