### PR TITLE
Support not finding a section

### DIFF
--- a/lucirpc/client_test.go
+++ b/lucirpc/client_test.go
@@ -220,7 +220,7 @@ func TestClientGetSection(t *testing.T) {
 		)
 
 		// Then
-		assert.ErrorContains(t, err, "invalid get section response")
+		assert.ErrorContains(t, err, "could not find section")
 	})
 
 	t.Run("returns section data when successful", func(t *testing.T) {


### PR DESCRIPTION
We don't always know that we'll find a section. Before, we were assuming
that any call to `lucirpc.GetSection` should always succeed. But if we
get a config/section that doesn't exist, we expect not to find anything.

We change to do a little more explicit checking.