### PR TITLE
Add support for creating a section in `lucirpc`

### DIFF
--- a/lucirpc/client_test.go
+++ b/lucirpc/client_test.go
@@ -14,6 +14,251 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func TestClientCreateSection(t *testing.T) {
+	t.Run("handles server not existing", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		close()
+
+		// When
+		_, err := client.CreateSection(
+			ctx,
+			"",
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.ErrorContains(t, err, "problem sending request to create section")
+	})
+
+	t.Run("makes a request to correct endpoint", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/cgi-bin/luci/rpc/uci":
+				fmt.Fprintf(w, `{
+					"result": true
+				}`)
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		_, err := client.CreateSection(
+			ctx,
+			"",
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.NilError(t, err)
+	})
+
+	t.Run("expects a 200 response", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		_, err := client.CreateSection(
+			ctx,
+			"",
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.ErrorContains(t, err, "expected create section to respond with a 200")
+	})
+
+	t.Run("expects a valid JSON-RPC response", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `[]`)
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		_, err := client.CreateSection(
+			ctx,
+			"",
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.ErrorContains(t, err, "unable to parse create section response")
+	})
+
+	t.Run("returns error when get section fails", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{
+				"error": ""
+			}`)
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		_, err := client.CreateSection(
+			ctx,
+			"",
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.ErrorContains(t, err, "unable to create section")
+	})
+
+	t.Run("does not handle unknown stuff in result", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{
+				"result": 31
+			}`)
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		_, err := client.CreateSection(
+			ctx,
+			"",
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.ErrorContains(t, err, "unable to parse create section response")
+	})
+
+	t.Run("returns section data when successful", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{
+				"result": true
+			}`)
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		got, err := client.CreateSection(
+			ctx,
+			"",
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.NilError(t, err)
+		want := true
+		assert.DeepEqual(t, got, want)
+	})
+
+	t.Run("commits changes", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		var committed bool
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/cgi-bin/luci/rpc/uci":
+				decoder := json.NewDecoder(r.Body)
+				var body map[string]json.RawMessage
+				err := decoder.Decode(&body)
+				assert.NilError(t, err)
+				method, ok := body["method"]
+				assert.Check(t, ok)
+				switch string(method) {
+				case `"commit"`:
+					committed = true
+				}
+
+				fmt.Fprintf(w, `{
+					"result": true
+				}`)
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		client.CreateSection(
+			ctx,
+			"",
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.Check(t, committed)
+	})
+}
+
 func TestClientGetSection(t *testing.T) {
 	t.Run("handles server not existing", func(t *testing.T) {
 		// Given

--- a/openwrt/internal/lucirpcglue/section.go
+++ b/openwrt/internal/lucirpcglue/section.go
@@ -9,6 +9,36 @@ import (
 	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 )
 
+// CreateSection attempts to create a new section.
+// The bool represents whether or not creation was successful.
+// Any diagnostic information found in the process (including errors) is returned.
+func CreateSection(
+	ctx context.Context,
+	client lucirpc.Client,
+	config string,
+	sectionType string,
+	section string,
+	options map[string]json.RawMessage,
+) (bool, diag.Diagnostics) {
+	diagnostics := diag.Diagnostics{}
+	result, err := client.CreateSection(
+		ctx,
+		config,
+		sectionType,
+		section,
+		options,
+	)
+	if err != nil {
+		diagnostics.AddError(
+			fmt.Sprintf("problem creating %s.%s section", config, section),
+			err.Error(),
+		)
+		return false, diagnostics
+	}
+
+	return result, diagnostics
+}
+
 // GetMetadataString attempts to parse the given metadata key from the section.
 // Any diagnostic information found in the process (including errors) is returned.
 func GetSection(


### PR DESCRIPTION
We want to be able to actually create things on an OpenWrt device. We
add this `CreateSection` method so that we can do exactly that.

Since this is where things start to get kind of weird for the LuCI
JSON-RPC API, we write some tests to catalog the behavior. These tests
show a bit of the inconsistency in the API. Thankfully, we've got a
package that tries to smooth some of that out for us.

This also shows the first time that we need to be concerned about
committing changes. When reading, we don't have to worry about that too
much, but the model for UCI is to have a distinction between changes
that are still in progress and changes that have been committed.

We decide not to worry about that (since every one of our consumers
would have to know about and follow this UCI pattern), and make it so
it's one action (at least in theory). If we find that it would be better
to follow this UCI pattern, we can always change the API to make it work
like that.