### PR TITLE
Add support for updating a section in `lucirpc`

### DIFF
--- a/lucirpc/client_test.go
+++ b/lucirpc/client_test.go
@@ -675,6 +675,243 @@ func TestNewClient(t *testing.T) {
 	})
 }
 
+func TestClientUpdateSection(t *testing.T) {
+	t.Run("handles server not existing", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		close()
+
+		// When
+		_, err := client.UpdateSection(
+			ctx,
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.ErrorContains(t, err, "problem sending request to update section")
+	})
+
+	t.Run("makes a request to correct endpoint", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/cgi-bin/luci/rpc/uci":
+				fmt.Fprintf(w, `{
+					"result": true
+				}`)
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		_, err := client.UpdateSection(
+			ctx,
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.NilError(t, err)
+	})
+
+	t.Run("expects a 200 response", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		_, err := client.UpdateSection(
+			ctx,
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.ErrorContains(t, err, "expected update section to respond with a 200")
+	})
+
+	t.Run("expects a valid JSON-RPC response", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `[]`)
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		_, err := client.UpdateSection(
+			ctx,
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.ErrorContains(t, err, "unable to parse update section response")
+	})
+
+	t.Run("returns error when get section fails", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{
+				"error": ""
+			}`)
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		_, err := client.UpdateSection(
+			ctx,
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.ErrorContains(t, err, "unable to update section")
+	})
+
+	t.Run("does not handle unknown stuff in result", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{
+				"result": 31
+			}`)
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		_, err := client.UpdateSection(
+			ctx,
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.ErrorContains(t, err, "unable to parse update section response")
+	})
+
+	t.Run("returns true when successful", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{
+				"result": true
+			}`)
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		got, err := client.UpdateSection(
+			ctx,
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.NilError(t, err)
+		want := true
+		assert.DeepEqual(t, got, want)
+	})
+
+	t.Run("commits changes", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		var committed bool
+		handle := func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/cgi-bin/luci/rpc/uci":
+				decoder := json.NewDecoder(r.Body)
+				var body map[string]json.RawMessage
+				err := decoder.Decode(&body)
+				assert.NilError(t, err)
+				method, ok := body["method"]
+				assert.Check(t, ok)
+				switch string(method) {
+				case `"commit"`:
+					committed = true
+				}
+
+				fmt.Fprintf(w, `{
+					"result": true
+				}`)
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}
+		client, close := authenticatedClient(
+			t,
+			ctx,
+			http.HandlerFunc(handle),
+		)
+		defer close()
+
+		// When
+		client.UpdateSection(
+			ctx,
+			"",
+			"",
+			map[string]json.RawMessage{},
+		)
+
+		// Then
+		assert.Check(t, committed)
+	})
+}
+
 func authenticatedClient(
 	t *testing.T,
 	ctx context.Context,

--- a/openwrt/internal/lucirpcglue/section.go
+++ b/openwrt/internal/lucirpcglue/section.go
@@ -59,3 +59,31 @@ func GetSection(
 
 	return result, diagnostics
 }
+
+// UpdateSection attempts to update an existing section.
+// The bool represents whether or not updating was successful.
+// Any diagnostic information found in the process (including errors) is returned.
+func UpdateSection(
+	ctx context.Context,
+	client lucirpc.Client,
+	config string,
+	section string,
+	options map[string]json.RawMessage,
+) (bool, diag.Diagnostics) {
+	diagnostics := diag.Diagnostics{}
+	result, err := client.UpdateSection(
+		ctx,
+		config,
+		section,
+		options,
+	)
+	if err != nil {
+		diagnostics.AddError(
+			fmt.Sprintf("problem updating %s.%s section", config, section),
+			err.Error(),
+		)
+		return false, diagnostics
+	}
+
+	return result, diagnostics
+}


### PR DESCRIPTION
We want to be able to update sections. This allows us to start managing
resources for real with Terraform. We'll probably need to flesh this out
more once we have a real resource going, but this should be good for
now.

We add a handful of tests to try and catch some of the behavior of this
API. We add both unit tests and acceptance tests.