### PR TITLE
Move handling of `bool` into glue code

### DIFF
--- a/openwrt/internal/lucirpcglue/section.go
+++ b/openwrt/internal/lucirpcglue/section.go
@@ -10,7 +10,6 @@ import (
 )
 
 // CreateSection attempts to create a new section.
-// The bool represents whether or not creation was successful.
 // Any diagnostic information found in the process (including errors) is returned.
 func CreateSection(
 	ctx context.Context,
@@ -19,7 +18,7 @@ func CreateSection(
 	sectionType string,
 	section string,
 	options map[string]json.RawMessage,
-) (bool, diag.Diagnostics) {
+) diag.Diagnostics {
 	diagnostics := diag.Diagnostics{}
 	result, err := client.CreateSection(
 		ctx,
@@ -33,21 +32,28 @@ func CreateSection(
 			fmt.Sprintf("problem creating %s.%s section", config, section),
 			err.Error(),
 		)
-		return false, diagnostics
+		return diagnostics
 	}
 
-	return result, diagnostics
+	if !result {
+		diagnostics.AddError(
+			fmt.Sprintf("Could not create %s.%s section", config, section),
+			"It is not currently known why this happens. It is unclear if this is a problem with the provider. Please double check the values provided are acceptable.",
+		)
+		return diagnostics
+	}
+
+	return diagnostics
 }
 
 // DeleteSection attempts to delete an existing section.
-// The bool represents whether or not deleting was successful.
 // Any diagnostic information found in the process (including errors) is returned.
 func DeleteSection(
 	ctx context.Context,
 	client lucirpc.Client,
 	config string,
 	section string,
-) (bool, diag.Diagnostics) {
+) diag.Diagnostics {
 	diagnostics := diag.Diagnostics{}
 	result, err := client.DeleteSection(
 		ctx,
@@ -59,10 +65,18 @@ func DeleteSection(
 			fmt.Sprintf("problem deleting %s.%s section", config, section),
 			err.Error(),
 		)
-		return false, diagnostics
+		return diagnostics
 	}
 
-	return result, diagnostics
+	if !result {
+		diagnostics.AddError(
+			fmt.Sprintf("Could not delete %s.%s section", config, section),
+			"It is not currently known why this happens. It is unclear if this is a problem with the provider. Please double check the values provided are acceptable.",
+		)
+		return diagnostics
+	}
+
+	return diagnostics
 }
 
 // GetMetadataString attempts to parse the given metadata key from the section.
@@ -87,7 +101,6 @@ func GetSection(
 }
 
 // UpdateSection attempts to update an existing section.
-// The bool represents whether or not updating was successful.
 // Any diagnostic information found in the process (including errors) is returned.
 func UpdateSection(
 	ctx context.Context,
@@ -95,7 +108,7 @@ func UpdateSection(
 	config string,
 	section string,
 	options map[string]json.RawMessage,
-) (bool, diag.Diagnostics) {
+) diag.Diagnostics {
 	diagnostics := diag.Diagnostics{}
 	result, err := client.UpdateSection(
 		ctx,
@@ -108,8 +121,16 @@ func UpdateSection(
 			fmt.Sprintf("problem updating %s.%s section", config, section),
 			err.Error(),
 		)
-		return false, diagnostics
+		return diagnostics
 	}
 
-	return result, diagnostics
+	if !result {
+		diagnostics.AddError(
+			fmt.Sprintf("Could not update %s.%s section", config, section),
+			"It is not currently known why this happens. It is unclear if this is a problem with the provider. Please double check the values provided are acceptable.",
+		)
+		return diagnostics
+	}
+
+	return diagnostics
 }

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -82,7 +82,7 @@ func (d *systemResource) Create(
 	}
 
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, systemUCISection))
-	ok, diagnostics := lucirpcglue.CreateSection(
+	diagnostics = lucirpcglue.CreateSection(
 		ctx,
 		d.client,
 		systemUCIConfig,
@@ -92,14 +92,6 @@ func (d *systemResource) Create(
 	)
 	res.Diagnostics.Append(diagnostics...)
 	if res.Diagnostics.HasError() {
-		return
-	}
-
-	if !ok {
-		res.Diagnostics.AddError(
-			fmt.Sprintf("Could not create %s.%s section", systemUCIConfig, systemUCISection),
-			"It is not currently known why this happens. It is unclear if this is a problem with the provider. Please double check the values provided are acceptable.",
-		)
 		return
 	}
 
@@ -144,7 +136,7 @@ func (d *systemResource) Delete(
 	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, id))
 	tflog.Debug(ctx, "Deleting existing section")
-	ok, diagnostics := lucirpcglue.DeleteSection(
+	diagnostics = lucirpcglue.DeleteSection(
 		ctx,
 		d.client,
 		systemUCIConfig,
@@ -152,14 +144,6 @@ func (d *systemResource) Delete(
 	)
 	res.Diagnostics.Append(diagnostics...)
 	if res.Diagnostics.HasError() {
-		return
-	}
-
-	if !ok {
-		res.Diagnostics.AddError(
-			fmt.Sprintf("Could not delete %s.%s section", systemUCIConfig, systemUCISection),
-			"It is not currently known why this happens. It is unclear if this is a problem with the provider. Please double check the values provided are acceptable.",
-		)
 		return
 	}
 }
@@ -265,7 +249,7 @@ func (d *systemResource) Update(
 	}
 
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, systemUCISection))
-	ok, diagnostics := lucirpcglue.UpdateSection(
+	diagnostics = lucirpcglue.UpdateSection(
 		ctx,
 		d.client,
 		systemUCIConfig,
@@ -274,14 +258,6 @@ func (d *systemResource) Update(
 	)
 	res.Diagnostics.Append(diagnostics...)
 	if res.Diagnostics.HasError() {
-		return
-	}
-
-	if !ok {
-		res.Diagnostics.AddError(
-			fmt.Sprintf("Could not create %s.%s section", systemUCIConfig, systemUCISection),
-			"It is not currently known why this happens. It is unclear if this is a problem with the provider. Please double check the values provided are acceptable.",
-		)
 		return
 	}
 


### PR DESCRIPTION
This might be a misstep, but it feels like not being able to create,
delete, or update the section should be an error outright and stuffed
into the `Diagnostics`. We switch to that in hopes that this is easier
in the long run.