### PR TITLE
Fetch the tags when making a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          # We need to fetch more history (all of it, currently) so we can compare previous tags.
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --force --tags
       - name: Install Nix
         uses: cachix/install-nix-action@v19
       - name: Import GPG


### PR DESCRIPTION
We also need more of the history in order to fetch the tags. We default
to fetching all of the history because we don't have that many commits
(and won't for a long time). If it starts to become an issue in a few
years, we can do something differently.