### PR TITLE
Move create/read/update to each attribute

### DIFF
--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"encoding/json"
 
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
+	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
@@ -57,43 +59,250 @@ const (
 )
 
 var (
-	systemConLogLevelSchemaAttribute = int64SchemaAttribute{
-		Description:       "The maximum log level for kernel messages to be logged to the console.",
+	systemConLogLevelSchemaAttribute = int64SchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+		Description: "The maximum log level for kernel messages to be logged to the console.",
+		ReadResponse: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			section map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, systemModel, diag.Diagnostics) {
+			ctx, value, diagnostics := lucirpcglue.GetOptionInt64(ctx, fullTypeName, terraformType, section, path.Root(systemConLogLevelAttribute), systemConLogLevelUCIOption)
+			model.ConLogLevel = value
+			return ctx, model, diagnostics
+		},
 		ResourceExistence: NoValidation,
+		UpsertRequest: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			options map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+			if !hasValue(model.ConLogLevel) {
+				return ctx, options, diag.Diagnostics{}
+			}
+
+			value, diagnostics := serializeInt64(model.ConLogLevel, path.Root(systemConLogLevelAttribute))
+			if diagnostics.HasError() {
+				return ctx, options, diagnostics
+			}
+
+			ctx = logger.SetFieldInt64(ctx, fullTypeName, resourceTerraformType, systemConLogLevelAttribute, model.ConLogLevel)
+			options[systemConLogLevelUCIOption] = value
+			return ctx, options, diag.Diagnostics{}
+		},
 	}
 
-	systemCronLogLevelSchemaAttribute = int64SchemaAttribute{
-		Description:       "The minimum level for cron messages to be logged to syslog.",
+	systemCronLogLevelSchemaAttribute = int64SchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+		Description: "The minimum level for cron messages to be logged to syslog.",
+		ReadResponse: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			section map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, systemModel, diag.Diagnostics) {
+			ctx, value, diagnostics := lucirpcglue.GetOptionInt64(ctx, fullTypeName, terraformType, section, path.Root(systemCronLogLevelAttribute), systemCronLogLevelUCIOption)
+			model.CronLogLevel = value
+			return ctx, model, diagnostics
+		},
 		ResourceExistence: NoValidation,
+		UpsertRequest: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			options map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+			if !hasValue(model.CronLogLevel) {
+				return ctx, options, diag.Diagnostics{}
+			}
+
+			value, diagnostics := serializeInt64(model.CronLogLevel, path.Root(systemCronLogLevelAttribute))
+			if diagnostics.HasError() {
+				return ctx, options, diagnostics
+			}
+
+			ctx = logger.SetFieldInt64(ctx, fullTypeName, resourceTerraformType, systemCronLogLevelAttribute, model.CronLogLevel)
+			options[systemCronLogLevelUCIOption] = value
+			return ctx, options, diag.Diagnostics{}
+		},
 	}
 
-	systemDescriptionSchemaAttribute = stringSchemaAttribute{
-		Description:       "The hostname for the system.",
+	systemDescriptionSchemaAttribute = stringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+		Description: "The hostname for the system.",
+		ReadResponse: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			section map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, systemModel, diag.Diagnostics) {
+			ctx, value, diagnostics := lucirpcglue.GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(systemDescriptionAttribute), systemDescriptionUCIOption)
+			model.Description = value
+			return ctx, model, diagnostics
+		},
 		ResourceExistence: NoValidation,
+		UpsertRequest: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			options map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+			if !hasValue(model.Description) {
+				return ctx, options, diag.Diagnostics{}
+			}
+
+			value, diagnostics := serializeString(model.Description, path.Root(systemDescriptionAttribute))
+			if diagnostics.HasError() {
+				return ctx, options, diagnostics
+			}
+
+			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemDescriptionAttribute, model.Description)
+			options[systemDescriptionUCIOption] = value
+			return ctx, options, diag.Diagnostics{}
+		},
 	}
 
-	systemHostnameSchemaAttribute = stringSchemaAttribute{
-		Description:       "A short single-line description for the system.",
+	systemHostnameSchemaAttribute = stringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+		Description: "A short single-line description for the system.",
+		ReadResponse: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			section map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, systemModel, diag.Diagnostics) {
+			ctx, value, diagnostics := lucirpcglue.GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(systemHostnameAttribute), systemHostnameUCIOption)
+			model.Hostname = value
+			return ctx, model, diagnostics
+		},
 		ResourceExistence: NoValidation,
+		UpsertRequest: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			options map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+			if !hasValue(model.Hostname) {
+				return ctx, options, diag.Diagnostics{}
+			}
+
+			value, diagnostics := serializeString(model.Hostname, path.Root(systemHostnameAttribute))
+			if diagnostics.HasError() {
+				return ctx, options, diagnostics
+			}
+
+			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemHostnameAttribute, model.Hostname)
+			options[systemHostnameUCIOption] = value
+			return ctx, options, diag.Diagnostics{}
+		},
 	}
 
-	systemIdSchemaAttribute = stringSchemaAttribute{
+	systemIdSchemaAttribute = stringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
 		DataSourceExistence: Required,
 		Description:         "Placeholder identifier attribute.",
-		ResourceExistence:   Required,
+		ReadResponse: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			section map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, systemModel, diag.Diagnostics) {
+			ctx, value, diagnostics := lucirpcglue.GetMetadataString(ctx, fullTypeName, terraformType, section, systemIdUCISection)
+			model.Id = value
+			return ctx, model, diagnostics
+		},
+		ResourceExistence: Required,
+		UpsertRequest: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			options map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemIdAttribute, model.Id)
+			return ctx, options, diag.Diagnostics{}
+		},
 	}
 
-	systemLogSizeSchemaAttribute = int64SchemaAttribute{
-		Description:       "Size of the file based log buffer in KiB.",
+	systemLogSizeSchemaAttribute = int64SchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+		Description: "Size of the file based log buffer in KiB.",
+		ReadResponse: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			section map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, systemModel, diag.Diagnostics) {
+			ctx, value, diagnostics := lucirpcglue.GetOptionInt64(ctx, fullTypeName, terraformType, section, path.Root(systemLogSizeAttribute), systemLogSizeUCIOption)
+			model.LogSize = value
+			return ctx, model, diagnostics
+		},
 		ResourceExistence: NoValidation,
+		UpsertRequest: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			options map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+			if !hasValue(model.LogSize) {
+				return ctx, options, diag.Diagnostics{}
+			}
+
+			value, diagnostics := serializeInt64(model.LogSize, path.Root(systemLogSizeAttribute))
+			if diagnostics.HasError() {
+				return ctx, options, diagnostics
+			}
+
+			ctx = logger.SetFieldInt64(ctx, fullTypeName, resourceTerraformType, systemLogSizeAttribute, model.LogSize)
+			options[systemLogSizeUCIOption] = value
+			return ctx, options, diag.Diagnostics{}
+		},
 	}
 
-	systemNotesSchemaAttribute = stringSchemaAttribute{
-		Description:       "Multi-line free-form text about the system.",
+	systemNotesSchemaAttribute = stringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+		Description: "Multi-line free-form text about the system.",
+		ReadResponse: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			section map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, systemModel, diag.Diagnostics) {
+			ctx, value, diagnostics := lucirpcglue.GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(systemNotesAttribute), systemNotesUCIOption)
+			model.Notes = value
+			return ctx, model, diagnostics
+		},
 		ResourceExistence: NoValidation,
+		UpsertRequest: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			options map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+			if !hasValue(model.Notes) {
+				return ctx, options, diag.Diagnostics{}
+			}
+
+			value, diagnostics := serializeString(model.Notes, path.Root(systemNotesAttribute))
+			if diagnostics.HasError() {
+				return ctx, options, diagnostics
+			}
+
+			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemNotesAttribute, model.Notes)
+			options[systemNotesUCIOption] = value
+			return ctx, options, diag.Diagnostics{}
+		},
 	}
 
-	systemSchemaAttributes = map[string]schemaAttribute{
+	systemSchemaAttributes = map[string]schemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
 		systemConLogLevelAttribute:  systemConLogLevelSchemaAttribute,
 		systemCronLogLevelAttribute: systemCronLogLevelSchemaAttribute,
 		systemDescriptionAttribute:  systemDescriptionSchemaAttribute,
@@ -106,19 +315,112 @@ var (
 		systemZonenameAttribute:     systemZonenameSchemaAttribute,
 	}
 
-	systemTimezoneSchemaAttribute = stringSchemaAttribute{
-		Description:       "The POSIX.1 time zone string. This has no corresponding value in LuCI. See: https://github.com/openwrt/luci/blob/cd82ccacef78d3bb8b8af6b87dabb9e892e2b2aa/modules/luci-base/luasrc/sys/zoneinfo/tzdata.lua.",
+	systemTimezoneSchemaAttribute = stringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+		Description: "The POSIX.1 time zone string. This has no corresponding value in LuCI. See: https://github.com/openwrt/luci/blob/cd82ccacef78d3bb8b8af6b87dabb9e892e2b2aa/modules/luci-base/luasrc/sys/zoneinfo/tzdata.lua.",
+		ReadResponse: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			section map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, systemModel, diag.Diagnostics) {
+			ctx, value, diagnostics := lucirpcglue.GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(systemTimezoneAttribute), systemTimezoneUCIOption)
+			model.Timezone = value
+			return ctx, model, diagnostics
+		},
 		ResourceExistence: NoValidation,
+		UpsertRequest: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			options map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+			if !hasValue(model.Timezone) {
+				return ctx, options, diag.Diagnostics{}
+			}
+
+			value, diagnostics := serializeString(model.Timezone, path.Root(systemTimezoneAttribute))
+			if diagnostics.HasError() {
+				return ctx, options, diagnostics
+			}
+
+			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemTimezoneAttribute, model.Timezone)
+			options[systemTimezoneUCIOption] = value
+			return ctx, options, diag.Diagnostics{}
+		},
 	}
 
-	systemTtyLoginSchemaAttribute = boolSchemaAttribute{
-		Description:       "Require authentication for local users to log in the system.",
+	systemTtyLoginSchemaAttribute = boolSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+		Description: "Require authentication for local users to log in the system.",
+		ReadResponse: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			section map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, systemModel, diag.Diagnostics) {
+			ctx, value, diagnostics := lucirpcglue.GetOptionBool(ctx, fullTypeName, terraformType, section, path.Root(systemTTYLoginAttribute), systemTTYLoginUCIOption)
+			model.TTYLogin = value
+			return ctx, model, diagnostics
+		},
 		ResourceExistence: NoValidation,
+		UpsertRequest: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			options map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+			if !hasValue(model.TTYLogin) {
+				return ctx, options, diag.Diagnostics{}
+			}
+
+			value, diagnostics := serializeBool(model.TTYLogin, path.Root(systemTTYLoginAttribute))
+			if diagnostics.HasError() {
+				return ctx, options, diagnostics
+			}
+
+			ctx = logger.SetFieldBool(ctx, fullTypeName, resourceTerraformType, systemTTYLoginAttribute, model.TTYLogin)
+			options[systemTTYLoginUCIOption] = value
+			return ctx, options, diag.Diagnostics{}
+		},
 	}
 
-	systemZonenameSchemaAttribute = stringSchemaAttribute{
-		Description:       "The IANA/Olson time zone string. This corresponds to \"Timezone\" in LuCI. See: https://github.com/openwrt/luci/blob/cd82ccacef78d3bb8b8af6b87dabb9e892e2b2aa/modules/luci-base/luasrc/sys/zoneinfo/tzdata.lua.",
+	systemZonenameSchemaAttribute = stringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+		Description: "The IANA/Olson time zone string. This corresponds to \"Timezone\" in LuCI. See: https://github.com/openwrt/luci/blob/cd82ccacef78d3bb8b8af6b87dabb9e892e2b2aa/modules/luci-base/luasrc/sys/zoneinfo/tzdata.lua.",
+		ReadResponse: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			section map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, systemModel, diag.Diagnostics) {
+			ctx, value, diagnostics := lucirpcglue.GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(systemZonenameAttribute), systemZonenameUCIOption)
+			model.Zonename = value
+			return ctx, model, diagnostics
+		},
 		ResourceExistence: NoValidation,
+		UpsertRequest: func(
+			ctx context.Context,
+			fullTypeName string,
+			terraformType string,
+			options map[string]json.RawMessage,
+			model systemModel,
+		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+			if !hasValue(model.Zonename) {
+				return ctx, options, diag.Diagnostics{}
+			}
+
+			value, diagnostics := serializeString(model.Zonename, path.Root(systemZonenameAttribute))
+			if diagnostics.HasError() {
+				return ctx, options, diagnostics
+			}
+
+			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemZonenameAttribute, model.Zonename)
+			options[systemZonenameUCIOption] = value
+			return ctx, options, diag.Diagnostics{}
+		},
 	}
 )
 
@@ -168,41 +470,41 @@ func ReadModel(
 		return ctx, model, allDiagnostics
 	}
 
-	ctx, model.ConLogLevel, diagnostics = lucirpcglue.GetOptionInt64(ctx, fullTypeName, terraformType, section, path.Root(systemConLogLevelAttribute), systemConLogLevelUCIOption)
-	allDiagnostics.Append(diagnostics...)
-	ctx, model.CronLogLevel, diagnostics = lucirpcglue.GetOptionInt64(ctx, fullTypeName, terraformType, section, path.Root(systemCronLogLevelAttribute), systemCronLogLevelUCIOption)
-	allDiagnostics.Append(diagnostics...)
-	ctx, model.Description, diagnostics = lucirpcglue.GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(systemDescriptionAttribute), systemDescriptionUCIOption)
-	allDiagnostics.Append(diagnostics...)
-	ctx, model.Hostname, diagnostics = lucirpcglue.GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(systemHostnameAttribute), systemHostnameUCIOption)
-	allDiagnostics.Append(diagnostics...)
-	ctx, model.LogSize, diagnostics = lucirpcglue.GetOptionInt64(ctx, fullTypeName, terraformType, section, path.Root(systemLogSizeAttribute), systemLogSizeUCIOption)
-	allDiagnostics.Append(diagnostics...)
-	ctx, model.Notes, diagnostics = lucirpcglue.GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(systemNotesAttribute), systemNotesUCIOption)
-	allDiagnostics.Append(diagnostics...)
-	ctx, model.Timezone, diagnostics = lucirpcglue.GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(systemTimezoneAttribute), systemTimezoneUCIOption)
-	allDiagnostics.Append(diagnostics...)
-	ctx, model.TTYLogin, diagnostics = lucirpcglue.GetOptionBool(ctx, fullTypeName, terraformType, section, path.Root(systemTTYLoginAttribute), systemTTYLoginUCIOption)
-	allDiagnostics.Append(diagnostics...)
-	ctx, model.Zonename, diagnostics = lucirpcglue.GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(systemZonenameAttribute), systemZonenameUCIOption)
-	allDiagnostics.Append(diagnostics...)
-	ctx, model.Id, diagnostics = lucirpcglue.GetMetadataString(ctx, fullTypeName, terraformType, section, systemIdUCISection)
-	allDiagnostics.Append(diagnostics...)
+	for _, attribute := range systemSchemaAttributes {
+		ctx, model, diagnostics = attribute.Read(ctx, fullTypeName, terraformType, section, model)
+		allDiagnostics.Append(diagnostics...)
+	}
 
 	return ctx, model, diagnostics
 }
 
-type boolSchemaAttribute struct {
+type boolSchemaAttribute[Model any, Request any, Response any] struct {
 	DataSourceExistence AttributeExistence
 	DeprecationMessage  string
 	Description         string
 	MarkdownDescription string
+	ReadResponse        func(context.Context, string, string, Response, Model) (context.Context, Model, diag.Diagnostics)
 	ResourceExistence   AttributeExistence
 	Sensitive           bool
+	UpsertRequest       func(context.Context, string, string, Request, Model) (context.Context, Request, diag.Diagnostics)
 	Validators          []validator.Bool
 }
 
-func (a boolSchemaAttribute) ToDataSource() datasourceschema.Attribute {
+func (a boolSchemaAttribute[Model, Request, Response]) Read(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	response Response,
+	model Model,
+) (context.Context, Model, diag.Diagnostics) {
+	if a.ReadResponse == nil {
+		return ctx, model, diag.Diagnostics{}
+	}
+
+	return a.ReadResponse(ctx, fullTypeName, terraformType, response, model)
+}
+
+func (a boolSchemaAttribute[Model, Request, Response]) ToDataSource() datasourceschema.Attribute {
 	return datasourceschema.BoolAttribute{
 		Computed:            a.DataSourceExistence.ToComputed(),
 		DeprecationMessage:  a.DeprecationMessage,
@@ -215,7 +517,7 @@ func (a boolSchemaAttribute) ToDataSource() datasourceschema.Attribute {
 	}
 }
 
-func (a boolSchemaAttribute) ToResource() resourceschema.Attribute {
+func (a boolSchemaAttribute[Model, Request, Response]) ToResource() resourceschema.Attribute {
 	return resourceschema.BoolAttribute{
 		Computed:            a.ResourceExistence.ToComputed(),
 		DeprecationMessage:  a.DeprecationMessage,
@@ -228,17 +530,47 @@ func (a boolSchemaAttribute) ToResource() resourceschema.Attribute {
 	}
 }
 
-type int64SchemaAttribute struct {
+func (a boolSchemaAttribute[Model, Request, Response]) Upsert(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	request Request,
+	model Model,
+) (context.Context, Request, diag.Diagnostics) {
+	if a.UpsertRequest == nil {
+		return ctx, request, diag.Diagnostics{}
+	}
+
+	return a.UpsertRequest(ctx, fullTypeName, terraformType, request, model)
+}
+
+type int64SchemaAttribute[Model any, Request any, Response any] struct {
 	DataSourceExistence AttributeExistence
 	DeprecationMessage  string
 	Description         string
 	MarkdownDescription string
+	ReadResponse        func(context.Context, string, string, Response, Model) (context.Context, Model, diag.Diagnostics)
 	ResourceExistence   AttributeExistence
 	Sensitive           bool
+	UpsertRequest       func(context.Context, string, string, Request, Model) (context.Context, Request, diag.Diagnostics)
 	Validators          []validator.Int64
 }
 
-func (a int64SchemaAttribute) ToDataSource() datasourceschema.Attribute {
+func (a int64SchemaAttribute[Model, Request, Response]) Read(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	response Response,
+	model Model,
+) (context.Context, Model, diag.Diagnostics) {
+	if a.ReadResponse == nil {
+		return ctx, model, diag.Diagnostics{}
+	}
+
+	return a.ReadResponse(ctx, fullTypeName, terraformType, response, model)
+}
+
+func (a int64SchemaAttribute[Model, Request, Response]) ToDataSource() datasourceschema.Attribute {
 	return datasourceschema.Int64Attribute{
 		Computed:            a.DataSourceExistence.ToComputed(),
 		DeprecationMessage:  a.DeprecationMessage,
@@ -251,7 +583,7 @@ func (a int64SchemaAttribute) ToDataSource() datasourceschema.Attribute {
 	}
 }
 
-func (a int64SchemaAttribute) ToResource() resourceschema.Attribute {
+func (a int64SchemaAttribute[Model, Request, Response]) ToResource() resourceschema.Attribute {
 	return resourceschema.Int64Attribute{
 		Computed:            a.ResourceExistence.ToComputed(),
 		DeprecationMessage:  a.DeprecationMessage,
@@ -264,22 +596,54 @@ func (a int64SchemaAttribute) ToResource() resourceschema.Attribute {
 	}
 }
 
-type schemaAttribute interface {
-	ToDataSource() datasourceschema.Attribute
-	ToResource() resourceschema.Attribute
+func (a int64SchemaAttribute[Model, Request, Response]) Upsert(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	request Request,
+	model Model,
+) (context.Context, Request, diag.Diagnostics) {
+	if a.UpsertRequest == nil {
+		return ctx, request, diag.Diagnostics{}
+	}
+
+	return a.UpsertRequest(ctx, fullTypeName, terraformType, request, model)
 }
 
-type stringSchemaAttribute struct {
+type schemaAttribute[Model any, Request any, Response any] interface {
+	Read(context.Context, string, string, Response, Model) (context.Context, Model, diag.Diagnostics)
+	ToDataSource() datasourceschema.Attribute
+	ToResource() resourceschema.Attribute
+	Upsert(context.Context, string, string, Request, Model) (context.Context, Request, diag.Diagnostics)
+}
+
+type stringSchemaAttribute[Model any, Request any, Response any] struct {
 	DataSourceExistence AttributeExistence
 	DeprecationMessage  string
 	Description         string
 	MarkdownDescription string
+	ReadResponse        func(context.Context, string, string, Response, Model) (context.Context, Model, diag.Diagnostics)
 	ResourceExistence   AttributeExistence
 	Sensitive           bool
+	UpsertRequest       func(context.Context, string, string, Request, Model) (context.Context, Request, diag.Diagnostics)
 	Validators          []validator.String
 }
 
-func (a stringSchemaAttribute) ToDataSource() datasourceschema.Attribute {
+func (a stringSchemaAttribute[Model, Request, Response]) Read(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	response Response,
+	model Model,
+) (context.Context, Model, diag.Diagnostics) {
+	if a.ReadResponse == nil {
+		return ctx, model, diag.Diagnostics{}
+	}
+
+	return a.ReadResponse(ctx, fullTypeName, terraformType, response, model)
+}
+
+func (a stringSchemaAttribute[Model, Request, Response]) ToDataSource() datasourceschema.Attribute {
 	return datasourceschema.StringAttribute{
 		Computed:            a.DataSourceExistence.ToComputed(),
 		DeprecationMessage:  a.DeprecationMessage,
@@ -292,7 +656,7 @@ func (a stringSchemaAttribute) ToDataSource() datasourceschema.Attribute {
 	}
 }
 
-func (a stringSchemaAttribute) ToResource() resourceschema.Attribute {
+func (a stringSchemaAttribute[Model, Request, Response]) ToResource() resourceschema.Attribute {
 	return resourceschema.StringAttribute{
 		Computed:            a.ResourceExistence.ToComputed(),
 		DeprecationMessage:  a.DeprecationMessage,
@@ -303,4 +667,18 @@ func (a stringSchemaAttribute) ToResource() resourceschema.Attribute {
 		Sensitive:           a.Sensitive,
 		Validators:          a.Validators,
 	}
+}
+
+func (a stringSchemaAttribute[Model, Request, Response]) Upsert(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	request Request,
+	model Model,
+) (context.Context, Request, diag.Diagnostics) {
+	if a.UpsertRequest == nil {
+		return ctx, request, diag.Diagnostics{}
+	}
+
+	return a.UpsertRequest(ctx, fullTypeName, terraformType, request, model)
 }

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -293,93 +293,15 @@ func generateAPIBody(
 	fullTypeName string,
 ) (context.Context, string, map[string]json.RawMessage, diag.Diagnostics) {
 	tflog.Info(ctx, "Generating API request body")
+	var diagnostics diag.Diagnostics
 	allDiagnostics := diag.Diagnostics{}
 	options := map[string]json.RawMessage{}
 
-	tflog.Debug(ctx, "Handling required attributes")
-	ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemIdAttribute, model.Id)
+	tflog.Debug(ctx, "Handling attributes")
 	id := model.Id.ValueString()
-
-	tflog.Debug(ctx, "Handling optional attributes")
-	if hasValue(model.ConLogLevel) {
-		value, diagnostics := serializeInt64(model.ConLogLevel, path.Root(systemConLogLevelAttribute))
+	for _, attribute := range systemSchemaAttributes {
+		ctx, options, diagnostics = attribute.Upsert(ctx, fullTypeName, resourceTerraformType, options, model)
 		allDiagnostics.Append(diagnostics...)
-		if !allDiagnostics.HasError() {
-			ctx = logger.SetFieldInt64(ctx, fullTypeName, resourceTerraformType, systemConLogLevelAttribute, model.ConLogLevel)
-			options[systemConLogLevelUCIOption] = value
-		}
-	}
-
-	if hasValue(model.CronLogLevel) {
-		value, diagnostics := serializeInt64(model.CronLogLevel, path.Root(systemCronLogLevelAttribute))
-		allDiagnostics.Append(diagnostics...)
-		if !allDiagnostics.HasError() {
-			ctx = logger.SetFieldInt64(ctx, fullTypeName, resourceTerraformType, systemCronLogLevelAttribute, model.CronLogLevel)
-			options[systemCronLogLevelUCIOption] = value
-		}
-	}
-
-	if hasValue(model.Description) {
-		value, diagnostics := serializeString(model.Description, path.Root(systemDescriptionAttribute))
-		allDiagnostics.Append(diagnostics...)
-		if !allDiagnostics.HasError() {
-			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemDescriptionAttribute, model.Description)
-			options[systemDescriptionUCIOption] = value
-		}
-	}
-
-	if hasValue(model.Hostname) {
-		value, diagnostics := serializeString(model.Hostname, path.Root(systemHostnameAttribute))
-		allDiagnostics.Append(diagnostics...)
-		if !allDiagnostics.HasError() {
-			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemHostnameAttribute, model.Hostname)
-			options[systemHostnameUCIOption] = value
-		}
-	}
-
-	if hasValue(model.LogSize) {
-		value, diagnostics := serializeInt64(model.LogSize, path.Root(systemLogSizeAttribute))
-		allDiagnostics.Append(diagnostics...)
-		if !allDiagnostics.HasError() {
-			ctx = logger.SetFieldInt64(ctx, fullTypeName, resourceTerraformType, systemLogSizeAttribute, model.LogSize)
-			options[systemLogSizeUCIOption] = value
-		}
-	}
-
-	if hasValue(model.Notes) {
-		value, diagnostics := serializeString(model.Notes, path.Root(systemNotesAttribute))
-		allDiagnostics.Append(diagnostics...)
-		if !allDiagnostics.HasError() {
-			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemNotesAttribute, model.Notes)
-			options[systemNotesUCIOption] = value
-		}
-	}
-
-	if hasValue(model.Timezone) {
-		value, diagnostics := serializeString(model.Timezone, path.Root(systemTimezoneAttribute))
-		allDiagnostics.Append(diagnostics...)
-		if !allDiagnostics.HasError() {
-			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemTimezoneAttribute, model.Timezone)
-			options[systemTimezoneUCIOption] = value
-		}
-	}
-
-	if hasValue(model.TTYLogin) {
-		value, diagnostics := serializeBool(model.TTYLogin, path.Root(systemTTYLoginAttribute))
-		allDiagnostics.Append(diagnostics...)
-		if !allDiagnostics.HasError() {
-			ctx = logger.SetFieldBool(ctx, fullTypeName, resourceTerraformType, systemTTYLoginAttribute, model.TTYLogin)
-			options[systemTTYLoginUCIOption] = value
-		}
-	}
-
-	if hasValue(model.Zonename) {
-		value, diagnostics := serializeString(model.Zonename, path.Root(systemZonenameAttribute))
-		allDiagnostics.Append(diagnostics...)
-		if !allDiagnostics.HasError() {
-			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemZonenameAttribute, model.Zonename)
-			options[systemZonenameUCIOption] = value
-		}
 	}
 
 	return ctx, id, options, allDiagnostics

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -282,11 +282,6 @@ func (d *systemResource) Update(
 	}
 }
 
-type attributeHasValue interface {
-	IsNull() bool
-	IsUnknown() bool
-}
-
 func generateAPIBody(
 	ctx context.Context,
 	model systemModel,
@@ -305,64 +300,4 @@ func generateAPIBody(
 	}
 
 	return ctx, id, options, allDiagnostics
-}
-
-func hasValue(
-	attribute attributeHasValue,
-) bool {
-	return !attribute.IsNull() && !attribute.IsUnknown()
-}
-
-func serializeBool(
-	attribute interface{ ValueBool() bool },
-	attributePath path.Path,
-) (json.RawMessage, diag.Diagnostics) {
-	diagnostics := diag.Diagnostics{}
-	value, err := json.Marshal(attribute.ValueBool())
-	if err != nil {
-		diagnostics.AddAttributeError(
-			attributePath,
-			"Could not serialize",
-			err.Error(),
-		)
-		return nil, diagnostics
-	}
-
-	return json.RawMessage(value), diagnostics
-}
-
-func serializeInt64(
-	attribute interface{ ValueInt64() int64 },
-	attributePath path.Path,
-) (json.RawMessage, diag.Diagnostics) {
-	diagnostics := diag.Diagnostics{}
-	value, err := json.Marshal(attribute.ValueInt64())
-	if err != nil {
-		diagnostics.AddAttributeError(
-			attributePath,
-			"Could not serialize",
-			err.Error(),
-		)
-		return nil, diagnostics
-	}
-
-	return json.RawMessage(value), diagnostics
-}
-
-func serializeString(
-	attribute interface{ ValueString() string },
-	attributePath path.Path,
-) (json.RawMessage, diag.Diagnostics) {
-	diagnostics := diag.Diagnostics{}
-	value, err := json.Marshal(attribute.ValueString())
-	if err != nil {
-		diagnostics.AddAttributeError(
-			attributePath,
-			"Could not serialize",
-			err.Error(),
-		)
-		return nil, diagnostics
-	}
-
-	return json.RawMessage(value), diagnostics
 }


### PR DESCRIPTION
We can move the logic for doing each of these things into the attributes
instead of having to do them in the Data Source and Resource methods.
This helps clean up those methods, while also co-locating the behavior
of each attribute with the rest of its logic.

Naïvely, it seems like this is how it should be anyway. Each attribute
should know how to perform the operations itself. But, maybe when we get
further into it, we'll find that this doesn't really work out the way
it's supposed to. That likely means there's probably a union type that
can't be expressed, but that's a story for another day.