### PR TITLE
Rename read helper

### DIFF
--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -154,7 +154,7 @@ var (
 	}
 )
 
-func ReadModel(
+func readSystemModel(
 	ctx context.Context,
 	fullTypeName string,
 	terraformType string,

--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -68,7 +68,7 @@ func (d *systemDataSource) Read(
 	res *datasource.ReadResponse,
 ) {
 	tflog.Info(ctx, fmt.Sprintf("Reading %s data source", d.fullTypeName))
-	ctx, model, diagnostics := ReadModel(
+	ctx, model, diagnostics := readSystemModel(
 		ctx,
 		d.fullTypeName,
 		dataSourceTerraformType,

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -96,7 +96,7 @@ func (d *systemResource) Create(
 	}
 
 	tflog.Debug(ctx, "Reading updated section")
-	ctx, model, diagnostics = ReadModel(
+	ctx, model, diagnostics = readSystemModel(
 		ctx,
 		d.fullTypeName,
 		resourceTerraformType,
@@ -185,7 +185,7 @@ func (d *systemResource) Read(
 		return
 	}
 
-	ctx, model, diagnostics = ReadModel(
+	ctx, model, diagnostics = readSystemModel(
 		ctx,
 		d.fullTypeName,
 		resourceTerraformType,
@@ -262,7 +262,7 @@ func (d *systemResource) Update(
 	}
 
 	tflog.Debug(ctx, "Reading updated section")
-	ctx, model, diagnostics = ReadModel(
+	ctx, model, diagnostics = readSystemModel(
 		ctx,
 		d.fullTypeName,
 		resourceTerraformType,


### PR DESCRIPTION
We rename this helper so it's a bit more descriptive what is being read.
We also make it private to the package, since it's only used in this
package.