### PR TITLE
Move terraform types to the "glue" package

### DIFF
--- a/openwrt/internal/lucirpcglue/terraform_type.go
+++ b/openwrt/internal/lucirpcglue/terraform_type.go
@@ -1,0 +1,7 @@
+package lucirpcglue
+
+const (
+	DataSourceTerraformType = "data_source"
+
+	ResourceTerraformType = "resource"
+)

--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -100,7 +100,7 @@ var (
 			options map[string]json.RawMessage,
 			model systemModel,
 		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
-			ctx = logger.SetFieldString(ctx, fullTypeName, resourceTerraformType, systemIdAttribute, model.Id)
+			ctx = logger.SetFieldString(ctx, fullTypeName, lucirpcglue.ResourceTerraformType, systemIdAttribute, model.Id)
 			return ctx, options, diag.Diagnostics{}
 		},
 	}

--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -11,10 +11,6 @@ import (
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
-const (
-	dataSourceTerraformType = "data_source"
-)
-
 var (
 	_ datasource.DataSource              = &systemDataSource{}
 	_ datasource.DataSourceWithConfigure = &systemDataSource{}
@@ -71,7 +67,7 @@ func (d *systemDataSource) Read(
 	ctx, model, diagnostics := readSystemModel(
 		ctx,
 		d.fullTypeName,
-		dataSourceTerraformType,
+		lucirpcglue.DataSourceTerraformType,
 		d.client,
 		systemUCISection,
 	)

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -15,10 +15,6 @@ import (
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
-const (
-	resourceTerraformType = "resource"
-)
-
 var (
 	_ resource.Resource                = &systemResource{}
 	_ resource.ResourceWithConfigure   = &systemResource{}
@@ -99,7 +95,7 @@ func (d *systemResource) Create(
 	ctx, model, diagnostics = readSystemModel(
 		ctx,
 		d.fullTypeName,
-		resourceTerraformType,
+		lucirpcglue.ResourceTerraformType,
 		d.client,
 		id,
 	)
@@ -132,7 +128,7 @@ func (d *systemResource) Delete(
 		return
 	}
 
-	ctx = logger.SetFieldString(ctx, d.fullTypeName, resourceTerraformType, systemIdAttribute, model.Id)
+	ctx = logger.SetFieldString(ctx, d.fullTypeName, lucirpcglue.ResourceTerraformType, systemIdAttribute, model.Id)
 	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, id))
 	tflog.Debug(ctx, "Deleting existing section")
@@ -188,7 +184,7 @@ func (d *systemResource) Read(
 	ctx, model, diagnostics = readSystemModel(
 		ctx,
 		d.fullTypeName,
-		resourceTerraformType,
+		lucirpcglue.ResourceTerraformType,
 		d.client,
 		model.Id.ValueString(),
 	)
@@ -265,7 +261,7 @@ func (d *systemResource) Update(
 	ctx, model, diagnostics = readSystemModel(
 		ctx,
 		d.fullTypeName,
-		resourceTerraformType,
+		lucirpcglue.ResourceTerraformType,
 		d.client,
 		id,
 	)
@@ -295,7 +291,7 @@ func generateAPIBody(
 	tflog.Debug(ctx, "Handling attributes")
 	id := model.Id.ValueString()
 	for _, attribute := range systemSchemaAttributes {
-		ctx, options, diagnostics = attribute.Upsert(ctx, fullTypeName, resourceTerraformType, options, model)
+		ctx, options, diagnostics = attribute.Upsert(ctx, fullTypeName, lucirpcglue.ResourceTerraformType, options, model)
 		allDiagnostics.Append(diagnostics...)
 	}
 


### PR DESCRIPTION
These really ought to be in a proper Terraform package. But we stick
them here, since there's no better place for them.

It's entirely possible that these exist somewhere else in the world. In
which case, we could pull them in from there instead of defining them
here ourselves.