### PR TITLE
Hold onto the Terraform type at the start

### DIFF
--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -21,8 +21,9 @@ func NewSystemDataSource() datasource.DataSource {
 }
 
 type systemDataSource struct {
-	client       lucirpc.Client
-	fullTypeName string
+	client        lucirpc.Client
+	fullTypeName  string
+	terraformType string
 }
 
 // Configure prepares the data source.
@@ -54,6 +55,7 @@ func (d *systemDataSource) Metadata(
 ) {
 	fullTypeName := fmt.Sprintf("%s_%s", req.ProviderTypeName, systemTypeName)
 	d.fullTypeName = fullTypeName
+	d.terraformType = lucirpcglue.DataSourceTerraformType
 	res.TypeName = fullTypeName
 }
 
@@ -67,7 +69,7 @@ func (d *systemDataSource) Read(
 	ctx, model, diagnostics := readSystemModel(
 		ctx,
 		d.fullTypeName,
-		lucirpcglue.DataSourceTerraformType,
+		d.terraformType,
 		d.client,
 		systemUCISection,
 	)

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -24,8 +24,9 @@ func NewSystemResource() resource.Resource {
 }
 
 type systemResource struct {
-	client       lucirpc.Client
-	fullTypeName string
+	client        lucirpc.Client
+	fullTypeName  string
+	terraformType string
 }
 
 // Configure adds the provider configured client to the resource.
@@ -92,7 +93,7 @@ func (d *systemResource) Create(
 	ctx, model, diagnostics = readSystemModel(
 		ctx,
 		d.fullTypeName,
-		lucirpcglue.ResourceTerraformType,
+		d.terraformType,
 		d.client,
 		id,
 	)
@@ -125,7 +126,7 @@ func (d *systemResource) Delete(
 		return
 	}
 
-	ctx = logger.SetFieldString(ctx, d.fullTypeName, lucirpcglue.ResourceTerraformType, systemIdAttribute, model.Id)
+	ctx = logger.SetFieldString(ctx, d.fullTypeName, d.terraformType, systemIdAttribute, model.Id)
 	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, id))
 	tflog.Debug(ctx, "Deleting existing section")
@@ -159,6 +160,7 @@ func (d *systemResource) Metadata(
 ) {
 	fullTypeName := fmt.Sprintf("%s_%s", req.ProviderTypeName, systemTypeName)
 	d.fullTypeName = fullTypeName
+	d.terraformType = lucirpcglue.ResourceTerraformType
 	res.TypeName = fullTypeName
 }
 
@@ -181,7 +183,7 @@ func (d *systemResource) Read(
 	ctx, model, diagnostics = readSystemModel(
 		ctx,
 		d.fullTypeName,
-		lucirpcglue.ResourceTerraformType,
+		d.terraformType,
 		d.client,
 		model.Id.ValueString(),
 	)
@@ -257,7 +259,7 @@ func (d *systemResource) Update(
 	ctx, model, diagnostics = readSystemModel(
 		ctx,
 		d.fullTypeName,
-		lucirpcglue.ResourceTerraformType,
+		d.terraformType,
 		d.client,
 		id,
 	)


### PR DESCRIPTION
We don't really want to have to remember which Terraform type we're
dealing with once we get setup. Instead, we can set it at the start (in
`Metadata`) and carry it throughout the lifecycle.