### PR TITLE
Extract `system.system` schema descriptions

### DIFF
--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -34,6 +34,8 @@ const (
 	systemNotesAttribute = "notes"
 	systemNotesUCIOption = "notes"
 
+	systemSchemaDescription = "Provides system data about an OpenWrt device"
+
 	systemTimezoneAttribute = "timezone"
 	systemTimezoneUCIOption = "timezone"
 

--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -99,6 +99,6 @@ func (d *systemDataSource) Schema(
 
 	res.Schema = schema.Schema{
 		Attributes:  attributes,
-		Description: "Provides system data about an OpenWrt device",
+		Description: systemSchemaDescription,
 	}
 }

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -213,7 +213,7 @@ func (d *systemResource) Schema(
 
 	res.Schema = schema.Schema{
 		Attributes:  attributes,
-		Description: "Provides system data about an OpenWrt device",
+		Description: systemSchemaDescription,
 	}
 }
 


### PR DESCRIPTION
This is (or at least should) be the same for both Data Sources and
Resources. We pull it up to a common logcation for both.