### PR TITLE
Move acceptance test setup to their own file

### DIFF
--- a/openwrt/internal/network/acceptance_test.go
+++ b/openwrt/internal/network/acceptance_test.go
@@ -1,0 +1,40 @@
+//go:build acceptance.test
+
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
+	"github.com/ory/dockertest/v3"
+)
+
+var (
+	dockerPool *dockertest.Pool
+)
+
+func TestMain(m *testing.M) {
+	var (
+		code     int
+		err      error
+		tearDown func()
+	)
+	ctx := context.Background()
+	tearDown, dockerPool, err = acceptancetest.Setup(ctx, m)
+	defer func() {
+		tearDown()
+		os.Exit(code)
+	}()
+	if err != nil {
+		fmt.Printf("Problem setting up tests: %s", err)
+		code = 1
+		return
+	}
+
+	log.Printf("Running tests")
+	code = m.Run()
+}

--- a/openwrt/internal/network/globals_data_source_acceptance_test.go
+++ b/openwrt/internal/network/globals_data_source_acceptance_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -16,35 +14,8 @@ import (
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
 	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt"
-	"github.com/ory/dockertest/v3"
 	"gotest.tools/v3/assert"
 )
-
-var (
-	dockerPool *dockertest.Pool
-)
-
-func TestMain(m *testing.M) {
-	var (
-		code     int
-		err      error
-		tearDown func()
-	)
-	ctx := context.Background()
-	tearDown, dockerPool, err = acceptancetest.Setup(ctx, m)
-	defer func() {
-		tearDown()
-		os.Exit(code)
-	}()
-	if err != nil {
-		fmt.Printf("Problem setting up tests: %s", err)
-		code = 1
-		return
-	}
-
-	log.Printf("Running tests")
-	code = m.Run()
-}
 
 func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 	t.Parallel()

--- a/openwrt/internal/system/acceptance_test.go
+++ b/openwrt/internal/system/acceptance_test.go
@@ -1,0 +1,40 @@
+//go:build acceptance.test
+
+package system_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
+	"github.com/ory/dockertest/v3"
+)
+
+var (
+	dockerPool *dockertest.Pool
+)
+
+func TestMain(m *testing.M) {
+	var (
+		code     int
+		err      error
+		tearDown func()
+	)
+	ctx := context.Background()
+	tearDown, dockerPool, err = acceptancetest.Setup(ctx, m)
+	defer func() {
+		tearDown()
+		os.Exit(code)
+	}()
+	if err != nil {
+		fmt.Printf("Problem setting up tests: %s", err)
+		code = 1
+		return
+	}
+
+	log.Printf("Running tests")
+	code = m.Run()
+}

--- a/openwrt/internal/system/system_data_source_acceptance_test.go
+++ b/openwrt/internal/system/system_data_source_acceptance_test.go
@@ -5,8 +5,6 @@ package system_test
 import (
 	"context"
 	"fmt"
-	"log"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -14,34 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt"
-	"github.com/ory/dockertest/v3"
 )
-
-var (
-	dockerPool *dockertest.Pool
-)
-
-func TestMain(m *testing.M) {
-	var (
-		code     int
-		err      error
-		tearDown func()
-	)
-	ctx := context.Background()
-	tearDown, dockerPool, err = acceptancetest.Setup(ctx, m)
-	defer func() {
-		tearDown()
-		os.Exit(code)
-	}()
-	if err != nil {
-		fmt.Printf("Problem setting up tests: %s", err)
-		code = 1
-		return
-	}
-
-	log.Printf("Running tests")
-	code = m.Run()
-}
 
 func TestSystemSystemDataSourceAcceptance(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
These tests shouldn't be in the Data Source-specific acceptance test
files. There's not really a great place for this stuff, since we have to
share this `*dockertest.Pool` between the tests, and tests don't really
have a way to pass down setup.

Maybe we can find a better way to deal with this in the future. Until
then, this should make the test files a bit more consistent.