### PR TITLE
Use the `resource.ParallelTest` helper

### DIFF
--- a/openwrt/internal/network/globals_data_source_acceptance_test.go
+++ b/openwrt/internal/network/globals_data_source_acceptance_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -37,7 +35,7 @@ func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, ok)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
 		},

--- a/openwrt/internal/system/system_data_source_acceptance_test.go
+++ b/openwrt/internal/system/system_data_source_acceptance_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestSystemSystemDataSourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -25,7 +23,7 @@ func TestSystemSystemDataSourceAcceptance(t *testing.T) {
 	)
 	defer openWrt.Close()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
 		},


### PR DESCRIPTION
It's effectively the same as calling `t.Parallel()`, but one less thing
to remember.