### PR TITLE
Don't use `resource.ParallelTest`

### DIFF
--- a/openwrt/internal/network/globals_data_source_acceptance_test.go
+++ b/openwrt/internal/network/globals_data_source_acceptance_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -35,7 +37,7 @@ func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, ok)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
 		},

--- a/openwrt/internal/network/globals_resource_acceptance_test.go
+++ b/openwrt/internal/network/globals_resource_acceptance_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestNetworkGlobalsResourceAcceptance(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -79,7 +81,7 @@ resource "openwrt_network_globals" "this" {
 		),
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
 		},

--- a/openwrt/internal/system/system_data_source_acceptance_test.go
+++ b/openwrt/internal/system/system_data_source_acceptance_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestSystemSystemDataSourceAcceptance(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -23,7 +25,7 @@ func TestSystemSystemDataSourceAcceptance(t *testing.T) {
 	)
 	defer openWrt.Close()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
 		},

--- a/openwrt/internal/system/system_resource_acceptance_test.go
+++ b/openwrt/internal/system/system_resource_acceptance_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestSystemSystemResourceAcceptance(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -85,7 +87,7 @@ resource "openwrt_system_system" "this" {
 		),
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
 		},


### PR DESCRIPTION
While `resource.ParallelTest` would normally be equivalent to using
`testing.Parallel` followed by `resource.Test`, it's not quite the same
for these test cases.

We do some setup work to have the OpenWrt server running in the test.
Since that setup work hasn't been marked as parallel (by a
`testing.Parallel` call) it runs serially. So we end up with a chunk of
the test cases running serially, and a chunk of them running in
parallel. While that's an interesting observation, that's not what we
want.

Instead, we explicitly mark the start of the test case as parallel with
`testing.Parallel`, and then use the `resource.Test` helper. This lets
the entire test case be run in parallel with the others.

The end result of this change is that instead of each test waiting the
5-10 seconds required for the OpenWrt server to be healthy before
allowing other tests to run, we spin up all of the OpenWrt servers at
the same time (or close enough to it to not matter). The time in the
test suite grows at a constant rate instead of at a linear rate with the
amount of tests.