### PR TITLE
Support sets of strings as attributes

### DIFF
--- a/openwrt/internal/logger/log.go
+++ b/openwrt/internal/logger/log.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -28,6 +30,30 @@ func SetFieldInt64(
 	value interface{ ValueInt64() int64 },
 ) context.Context {
 	ctx = tflog.SetField(ctx, fmt.Sprintf("%s_%s_%s", fullTypeName, terraformType, key), value.ValueInt64())
+	return ctx
+}
+
+// SetFieldSetString sets a set of strings field on the logger in the [context.Context].
+func SetFieldSetString(
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	key string,
+	value interface{ Elements() []attr.Value },
+) context.Context {
+	values := []string{}
+	elements := value.Elements()
+	for _, element := range elements {
+		var value string
+		diagnostics := tfsdk.ValueAs(ctx, element, &value)
+		if diagnostics.HasError() {
+			continue
+		}
+
+		values = append(values, value)
+	}
+
+	ctx = tflog.SetField(ctx, fmt.Sprintf("%s_%s_%s", fullTypeName, terraformType, key), values)
 	return ctx
 }
 


### PR DESCRIPTION
There are quite a few sets of things in OpenWrt. We need to start
supporting them. One of the soon-to-be-needed attributes is the ports on
a bridge device. Those ports are a set of strings (even if UCI
represents them as a list of strings). So, we add support for attributes
that are sets of strings.

This work will almost surely need to be adjusted as we get more
experience with the attributes. So this work will change over time.

This work also doesn't preclude lists of strings. We just don't have an
immediate need for them at the moment.