### PR TITLE
Also support validating set and string attributes

### DIFF
--- a/openwrt/internal/lucirpcglue/attribute.go
+++ b/openwrt/internal/lucirpcglue/attribute.go
@@ -25,8 +25,10 @@ const (
 )
 
 var (
-	_ validator.Bool  = requiresAttribute[any]{}
-	_ validator.Int64 = requiresAttribute[any]{}
+	_ validator.Bool   = requiresAttribute[any]{}
+	_ validator.Int64  = requiresAttribute[any]{}
+	_ validator.Set    = requiresAttribute[any]{}
+	_ validator.String = requiresAttribute[any]{}
 )
 
 type AttributeExistence int
@@ -562,6 +564,30 @@ func (a requiresAttribute[Value]) ValidateInt64(
 	ctx context.Context,
 	req validator.Int64Request,
 	res *validator.Int64Response,
+) {
+	diagnostics := a.validate(ctx, req.Config, req.Path, req.ConfigValue)
+	res.Diagnostics.Append(diagnostics...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (a requiresAttribute[Value]) ValidateSet(
+	ctx context.Context,
+	req validator.SetRequest,
+	res *validator.SetResponse,
+) {
+	diagnostics := a.validate(ctx, req.Config, req.Path, req.ConfigValue)
+	res.Diagnostics.Append(diagnostics...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (a requiresAttribute[Value]) ValidateString(
+	ctx context.Context,
+	req validator.StringRequest,
+	res *validator.StringResponse,
 ) {
 	diagnostics := a.validate(ctx, req.Config, req.Path, req.ConfigValue)
 	res.Diagnostics.Append(diagnostics...)


### PR DESCRIPTION
We missed this when adding the validator. But, we do want to support the
other types of attributes. Since we also have sets and strings, we add
support for those here.

The fact that there's no actual difference here should be telling that
the underlying abstraction isn't quite right. Probably, we need to our
adapter layer to be more distanced from the Terraform packages. There's
little reason we should have to deal with this much copy/paste just
because the underlying framework made some decisions that so far haven't
been beneficial to us.