### PR TITLE
Make helper for reading model

### DIFF
--- a/openwrt/internal/lucirpcglue/model.go
+++ b/openwrt/internal/lucirpcglue/model.go
@@ -1,0 +1,40 @@
+package lucirpcglue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
+)
+
+func ReadModel[Model any](
+	ctx context.Context,
+	fullTypeName string,
+	terraformType string,
+	client lucirpc.Client,
+	attributes map[string]SchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage],
+	uciConfig string,
+	uciSection string,
+) (context.Context, Model, diag.Diagnostics) {
+	tflog.Info(ctx, fmt.Sprintf("Reading %s model", fullTypeName))
+	var (
+		allDiagnostics diag.Diagnostics
+		model          Model
+	)
+
+	section, diagnostics := GetSection(ctx, client, uciConfig, uciSection)
+	allDiagnostics.Append(diagnostics...)
+	if allDiagnostics.HasError() {
+		return ctx, model, allDiagnostics
+	}
+
+	for _, attribute := range attributes {
+		ctx, model, diagnostics = attribute.Read(ctx, fullTypeName, terraformType, section, model)
+		allDiagnostics.Append(diagnostics...)
+	}
+
+	return ctx, model, diagnostics
+}

--- a/openwrt/internal/network/device.go
+++ b/openwrt/internal/network/device.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
@@ -284,30 +283,3 @@ func deviceModelSetMTU6(model *deviceModel, value types.Int64)          { model.
 func deviceModelSetName(model *deviceModel, value types.String)         { model.Name = value }
 func deviceModelSetTXQueueLength(model *deviceModel, value types.Int64) { model.TXQueueLength = value }
 func deviceModelSetType(model *deviceModel, value types.String)         { model.Type = value }
-
-func readDeviceModel(
-	ctx context.Context,
-	fullTypeName string,
-	terraformType string,
-	client lucirpc.Client,
-	sectionName string,
-) (context.Context, deviceModel, diag.Diagnostics) {
-	tflog.Info(ctx, "Reading device model")
-	var (
-		allDiagnostics diag.Diagnostics
-		model          deviceModel
-	)
-
-	section, diagnostics := lucirpcglue.GetSection(ctx, client, deviceUCIConfig, sectionName)
-	allDiagnostics.Append(diagnostics...)
-	if allDiagnostics.HasError() {
-		return ctx, model, allDiagnostics
-	}
-
-	for _, attribute := range deviceSchemaAttributes {
-		ctx, model, diagnostics = attribute.Read(ctx, fullTypeName, terraformType, section, model)
-		allDiagnostics.Append(diagnostics...)
-	}
-
-	return ctx, model, diagnostics
-}

--- a/openwrt/internal/network/device_data_source.go
+++ b/openwrt/internal/network/device_data_source.go
@@ -75,11 +75,13 @@ func (d *deviceDataSource) Read(
 		return
 	}
 
-	ctx, model, diagnostics = readDeviceModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		deviceSchemaAttributes,
+		deviceUCIConfig,
 		model.Id.ValueString(),
 	)
 	res.Diagnostics.Append(diagnostics...)

--- a/openwrt/internal/network/device_resource.go
+++ b/openwrt/internal/network/device_resource.go
@@ -90,11 +90,13 @@ func (d *deviceResource) Create(
 	}
 
 	tflog.Debug(ctx, "Reading updated section")
-	ctx, model, diagnostics = readDeviceModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		deviceSchemaAttributes,
+		deviceUCIConfig,
 		id,
 	)
 	res.Diagnostics.Append(diagnostics...)
@@ -180,11 +182,13 @@ func (d *deviceResource) Read(
 		return
 	}
 
-	ctx, model, diagnostics = readDeviceModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		deviceSchemaAttributes,
+		deviceUCIConfig,
 		model.Id.ValueString(),
 	)
 	res.Diagnostics.Append(diagnostics...)
@@ -256,11 +260,13 @@ func (d *deviceResource) Update(
 	}
 
 	tflog.Debug(ctx, "Reading updated section")
-	ctx, model, diagnostics = readDeviceModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		deviceSchemaAttributes,
+		deviceUCIConfig,
 		id,
 	)
 	res.Diagnostics.Append(diagnostics...)

--- a/openwrt/internal/network/globals.go
+++ b/openwrt/internal/network/globals.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
@@ -77,33 +76,6 @@ var (
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionBool(globalsModelGetPacketSteering, globalsPacketSteeringAttribute, globalsPacketSteeringUCIOption),
 	}
 )
-
-func readGlobalsModel(
-	ctx context.Context,
-	fullTypeName string,
-	terraformType string,
-	client lucirpc.Client,
-	sectionName string,
-) (context.Context, globalsModel, diag.Diagnostics) {
-	tflog.Info(ctx, "Reading globals model")
-	var (
-		allDiagnostics diag.Diagnostics
-		model          globalsModel
-	)
-
-	section, diagnostics := lucirpcglue.GetSection(ctx, client, globalsUCIConfig, sectionName)
-	allDiagnostics.Append(diagnostics...)
-	if allDiagnostics.HasError() {
-		return ctx, model, allDiagnostics
-	}
-
-	for _, attribute := range globalsSchemaAttributes {
-		ctx, model, diagnostics = attribute.Read(ctx, fullTypeName, terraformType, section, model)
-		allDiagnostics.Append(diagnostics...)
-	}
-
-	return ctx, model, diagnostics
-}
 
 type globalsModel struct {
 	Id             types.String `tfsdk:"id"`

--- a/openwrt/internal/network/globals_data_source.go
+++ b/openwrt/internal/network/globals_data_source.go
@@ -75,11 +75,13 @@ func (d *globalsDataSource) Read(
 		return
 	}
 
-	ctx, model, diagnostics = readGlobalsModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		globalsSchemaAttributes,
+		globalsUCIConfig,
 		model.Id.ValueString(),
 	)
 	res.Diagnostics.Append(diagnostics...)

--- a/openwrt/internal/network/globals_resource.go
+++ b/openwrt/internal/network/globals_resource.go
@@ -90,11 +90,13 @@ func (d *globalsResource) Create(
 	}
 
 	tflog.Debug(ctx, "Reading updated section")
-	ctx, model, diagnostics = readGlobalsModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		globalsSchemaAttributes,
+		globalsUCIConfig,
 		id,
 	)
 	res.Diagnostics.Append(diagnostics...)
@@ -180,11 +182,13 @@ func (d *globalsResource) Read(
 		return
 	}
 
-	ctx, model, diagnostics = readGlobalsModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		globalsSchemaAttributes,
+		globalsUCIConfig,
 		model.Id.ValueString(),
 	)
 	res.Diagnostics.Append(diagnostics...)
@@ -256,11 +260,13 @@ func (d *globalsResource) Update(
 	}
 
 	tflog.Debug(ctx, "Reading updated section")
-	ctx, model, diagnostics = readGlobalsModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		globalsSchemaAttributes,
+		globalsUCIConfig,
 		id,
 	)
 	res.Diagnostics.Append(diagnostics...)

--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
@@ -155,33 +154,6 @@ var (
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(systemModelGetZonename, systemZonenameAttribute, systemZonenameUCIOption),
 	}
 )
-
-func readSystemModel(
-	ctx context.Context,
-	fullTypeName string,
-	terraformType string,
-	client lucirpc.Client,
-	sectionName string,
-) (context.Context, systemModel, diag.Diagnostics) {
-	tflog.Info(ctx, "Reading system model")
-	var (
-		allDiagnostics diag.Diagnostics
-		model          systemModel
-	)
-
-	section, diagnostics := lucirpcglue.GetSection(ctx, client, systemUCIConfig, sectionName)
-	allDiagnostics.Append(diagnostics...)
-	if allDiagnostics.HasError() {
-		return ctx, model, allDiagnostics
-	}
-
-	for _, attribute := range systemSchemaAttributes {
-		ctx, model, diagnostics = attribute.Read(ctx, fullTypeName, terraformType, section, model)
-		allDiagnostics.Append(diagnostics...)
-	}
-
-	return ctx, model, diagnostics
-}
 
 type systemModel struct {
 	ConLogLevel  types.Int64  `tfsdk:"conloglevel"`

--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -66,11 +66,13 @@ func (d *systemDataSource) Read(
 	res *datasource.ReadResponse,
 ) {
 	tflog.Info(ctx, fmt.Sprintf("Reading %s data source", d.fullTypeName))
-	ctx, model, diagnostics := readSystemModel(
+	ctx, model, diagnostics := lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		systemSchemaAttributes,
+		systemUCIConfig,
 		systemUCISection,
 	)
 	res.Diagnostics.Append(diagnostics...)

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -90,11 +90,13 @@ func (d *systemResource) Create(
 	}
 
 	tflog.Debug(ctx, "Reading updated section")
-	ctx, model, diagnostics = readSystemModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		systemSchemaAttributes,
+		systemUCIConfig,
 		id,
 	)
 	res.Diagnostics.Append(diagnostics...)
@@ -180,11 +182,13 @@ func (d *systemResource) Read(
 		return
 	}
 
-	ctx, model, diagnostics = readSystemModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		systemSchemaAttributes,
+		systemUCIConfig,
 		model.Id.ValueString(),
 	)
 	res.Diagnostics.Append(diagnostics...)
@@ -256,11 +260,13 @@ func (d *systemResource) Update(
 	}
 
 	tflog.Debug(ctx, "Reading updated section")
-	ctx, model, diagnostics = readSystemModel(
+	ctx, model, diagnostics = lucirpcglue.ReadModel(
 		ctx,
 		d.fullTypeName,
 		d.terraformType,
 		d.client,
+		systemSchemaAttributes,
+		systemUCIConfig,
 		id,
 	)
 	res.Diagnostics.Append(diagnostics...)


### PR DESCRIPTION
We're doing the same thing in each of these, and there's no indication
that we're going to do something differently in the future. We pull this
logic to a centralized location and use it in the three different spots
we've got.

This isn't that huge of a change, since the duplicated behavior was
already pretty well abstracted, but it's a step to get us to seeing only
the differences rather than the similarities.