### PR TITLE
Grab the id outside of generating the API body

### DIFF
--- a/openwrt/internal/network/device.go
+++ b/openwrt/internal/network/device.go
@@ -244,20 +244,19 @@ type deviceModel struct {
 func (m deviceModel) generateAPIBody(
 	ctx context.Context,
 	fullTypeName string,
-) (context.Context, string, map[string]json.RawMessage, diag.Diagnostics) {
+) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
 	tflog.Info(ctx, "Generating API request body")
 	var diagnostics diag.Diagnostics
 	allDiagnostics := diag.Diagnostics{}
 	options := map[string]json.RawMessage{}
 
 	tflog.Debug(ctx, "Handling attributes")
-	id := m.Id.ValueString()
 	for _, attribute := range deviceSchemaAttributes {
 		ctx, options, diagnostics = attribute.Upsert(ctx, fullTypeName, lucirpcglue.ResourceTerraformType, options, m)
 		allDiagnostics.Append(diagnostics...)
 	}
 
-	return ctx, id, options, allDiagnostics
+	return ctx, options, allDiagnostics
 }
 
 func deviceModelGetBridgePorts(model deviceModel) types.Set         { return model.BridgePorts }

--- a/openwrt/internal/network/device_resource.go
+++ b/openwrt/internal/network/device_resource.go
@@ -66,7 +66,7 @@ func (d *deviceResource) Create(
 		return
 	}
 
-	ctx, id, options, diagnostics := model.generateAPIBody(
+	ctx, options, diagnostics := model.generateAPIBody(
 		ctx,
 		d.fullTypeName,
 	)
@@ -75,6 +75,7 @@ func (d *deviceResource) Create(
 		return
 	}
 
+	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", deviceUCIConfig, id))
 	diagnostics = lucirpcglue.CreateSection(
 		ctx,
@@ -237,7 +238,7 @@ func (d *deviceResource) Update(
 		return
 	}
 
-	ctx, id, options, diagnostics := model.generateAPIBody(
+	ctx, options, diagnostics := model.generateAPIBody(
 		ctx,
 		d.fullTypeName,
 	)
@@ -246,6 +247,7 @@ func (d *deviceResource) Update(
 		return
 	}
 
+	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", deviceUCIConfig, id))
 	diagnostics = lucirpcglue.UpdateSection(
 		ctx,

--- a/openwrt/internal/network/globals.go
+++ b/openwrt/internal/network/globals.go
@@ -86,20 +86,19 @@ type globalsModel struct {
 func (m globalsModel) generateAPIBody(
 	ctx context.Context,
 	fullTypeName string,
-) (context.Context, string, map[string]json.RawMessage, diag.Diagnostics) {
+) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
 	tflog.Info(ctx, "Generating API request body")
 	var diagnostics diag.Diagnostics
 	allDiagnostics := diag.Diagnostics{}
 	options := map[string]json.RawMessage{}
 
 	tflog.Debug(ctx, "Handling attributes")
-	id := m.Id.ValueString()
 	for _, attribute := range globalsSchemaAttributes {
 		ctx, options, diagnostics = attribute.Upsert(ctx, fullTypeName, lucirpcglue.ResourceTerraformType, options, m)
 		allDiagnostics.Append(diagnostics...)
 	}
 
-	return ctx, id, options, allDiagnostics
+	return ctx, options, allDiagnostics
 }
 
 func globalsModelGetPacketSteering(model globalsModel) types.Bool { return model.PacketSteering }

--- a/openwrt/internal/network/globals_resource.go
+++ b/openwrt/internal/network/globals_resource.go
@@ -66,7 +66,7 @@ func (d *globalsResource) Create(
 		return
 	}
 
-	ctx, id, options, diagnostics := model.generateAPIBody(
+	ctx, options, diagnostics := model.generateAPIBody(
 		ctx,
 		d.fullTypeName,
 	)
@@ -75,6 +75,7 @@ func (d *globalsResource) Create(
 		return
 	}
 
+	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", globalsUCIConfig, id))
 	diagnostics = lucirpcglue.CreateSection(
 		ctx,
@@ -237,7 +238,7 @@ func (d *globalsResource) Update(
 		return
 	}
 
-	ctx, id, options, diagnostics := model.generateAPIBody(
+	ctx, options, diagnostics := model.generateAPIBody(
 		ctx,
 		d.fullTypeName,
 	)
@@ -246,6 +247,7 @@ func (d *globalsResource) Update(
 		return
 	}
 
+	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", globalsUCIConfig, id))
 	diagnostics = lucirpcglue.UpdateSection(
 		ctx,

--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -171,20 +171,19 @@ type systemModel struct {
 func (m systemModel) generateAPIBody(
 	ctx context.Context,
 	fullTypeName string,
-) (context.Context, string, map[string]json.RawMessage, diag.Diagnostics) {
+) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
 	tflog.Info(ctx, "Generating API request body")
 	var diagnostics diag.Diagnostics
 	allDiagnostics := diag.Diagnostics{}
 	options := map[string]json.RawMessage{}
 
 	tflog.Debug(ctx, "Handling attributes")
-	id := m.Id.ValueString()
 	for _, attribute := range systemSchemaAttributes {
 		ctx, options, diagnostics = attribute.Upsert(ctx, fullTypeName, lucirpcglue.ResourceTerraformType, options, m)
 		allDiagnostics.Append(diagnostics...)
 	}
 
-	return ctx, id, options, allDiagnostics
+	return ctx, options, allDiagnostics
 }
 
 func systemModelGetConLogLevel(model systemModel) types.Int64  { return model.ConLogLevel }

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -66,7 +66,7 @@ func (d *systemResource) Create(
 		return
 	}
 
-	ctx, id, options, diagnostics := model.generateAPIBody(
+	ctx, options, diagnostics := model.generateAPIBody(
 		ctx,
 		d.fullTypeName,
 	)
@@ -75,6 +75,7 @@ func (d *systemResource) Create(
 		return
 	}
 
+	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, systemUCISection))
 	diagnostics = lucirpcglue.CreateSection(
 		ctx,
@@ -237,7 +238,7 @@ func (d *systemResource) Update(
 		return
 	}
 
-	ctx, id, options, diagnostics := model.generateAPIBody(
+	ctx, options, diagnostics := model.generateAPIBody(
 		ctx,
 		d.fullTypeName,
 	)
@@ -246,6 +247,7 @@ func (d *systemResource) Update(
 		return
 	}
 
+	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, systemUCISection))
 	diagnostics = lucirpcglue.UpdateSection(
 		ctx,


### PR DESCRIPTION
We don't actually need to return the id as part of the generation of the
API body. Each call-site has the model already (it's what the method is
being called on). Instead of doing that, we can grab the id outside of
the method when we need it.

This simplifies the API of the method a bit, but also makes it so we can
drop the hard requirement on having a model with this particular shape
of `Id` with a `ValueString` method while generating the API body. It
was a bit over-specified to begin with.