### PR TITLE
Use `system.system` id from the plan

### DIFF
--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -42,7 +42,6 @@ const (
 
 	systemTypeName      = "system_system"
 	systemUCIConfig     = "system"
-	systemUCISection    = "@system[0]"
 	systemUCISystemType = "system"
 
 	systemZonenameAttribute = "zonename"

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -78,7 +78,7 @@ func (d *systemResource) Create(
 	}
 
 	id := model.Id.ValueString()
-	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, systemUCISection))
+	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, id))
 	diagnostics = lucirpcglue.CreateSection(
 		ctx,
 		d.client,
@@ -252,7 +252,7 @@ func (d *systemResource) Update(
 	}
 
 	id := model.Id.ValueString()
-	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, systemUCISection))
+	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, id))
 	diagnostics = lucirpcglue.UpdateSection(
 		ctx,
 		d.client,


### PR DESCRIPTION
Similar to the change to use the id from the config, we use the id from
the plan instead of the anonymous syntax.