### PR TITLE
Make a helper for the id attribute

### DIFF
--- a/docs/data-sources/network_globals.md
+++ b/docs/data-sources/network_globals.md
@@ -32,7 +32,7 @@ output "network_globals" {
 
 ### Required
 
-- `id` (String) Name of the section.
+- `id` (String) Name of the section. This name is only used when interacting with UCI directly.
 
 ### Read-Only
 

--- a/docs/data-sources/system_system.md
+++ b/docs/data-sources/system_system.md
@@ -32,7 +32,7 @@ output "system_system" {
 
 ### Required
 
-- `id` (String) Placeholder identifier attribute.
+- `id` (String) Name of the section. This name is only used when interacting with UCI directly.
 
 ### Read-Only
 

--- a/docs/resources/network_globals.md
+++ b/docs/resources/network_globals.md
@@ -34,7 +34,7 @@ output "network_globals" {
 
 ### Required
 
-- `id` (String) Name of the section.
+- `id` (String) Name of the section. This name is only used when interacting with UCI directly.
 
 ### Optional
 

--- a/docs/resources/system_system.md
+++ b/docs/resources/system_system.md
@@ -34,7 +34,7 @@ output "system_system" {
 
 ### Required
 
-- `id` (String) Placeholder identifier attribute.
+- `id` (String) Name of the section. This name is only used when interacting with UCI directly.
 
 ### Optional
 

--- a/openwrt/internal/network/device_resource.go
+++ b/openwrt/internal/network/device_resource.go
@@ -131,7 +131,7 @@ func (d *deviceResource) Delete(
 		return
 	}
 
-	ctx = logger.SetFieldString(ctx, d.fullTypeName, d.terraformType, deviceIdAttribute, model.Id)
+	ctx = logger.SetFieldString(ctx, d.fullTypeName, d.terraformType, lucirpcglue.IdAttribute, model.Id)
 	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", deviceUCIConfig, id))
 	tflog.Debug(ctx, "Deleting existing section")
@@ -154,7 +154,7 @@ func (d *deviceResource) ImportState(
 	res *resource.ImportStateResponse,
 ) {
 	tflog.Debug(ctx, "Retrieving import id and saving to id attribute")
-	resource.ImportStatePassthroughID(ctx, path.Root(deviceIdAttribute), req, res)
+	resource.ImportStatePassthroughID(ctx, path.Root(lucirpcglue.IdAttribute), req, res)
 }
 
 // Metadata sets the resource type name.

--- a/openwrt/internal/network/globals.go
+++ b/openwrt/internal/network/globals.go
@@ -1,19 +1,13 @@
 package network
 
 import (
-	"context"
 	"encoding/json"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
 const (
-	globalsIdAttribute  = "id"
-	globalsIdUCISection = ".name"
-
 	globalsPacketSteeringAttribute = "packet_steering"
 	globalsPacketSteeringUCIOption = "packet_steering"
 
@@ -28,36 +22,10 @@ const (
 )
 
 var (
-	globalsIdSchemaAttribute = lucirpcglue.StringSchemaAttribute[globalsModel, map[string]json.RawMessage, map[string]json.RawMessage]{
-		DataSourceExistence: lucirpcglue.Required,
-		Description:         "Name of the section.",
-		ReadResponse: func(
-			ctx context.Context,
-			fullTypeName string,
-			terraformType string,
-			section map[string]json.RawMessage,
-			model globalsModel,
-		) (context.Context, globalsModel, diag.Diagnostics) {
-			ctx, value, diagnostics := lucirpcglue.GetMetadataString(ctx, fullTypeName, terraformType, section, globalsIdUCISection)
-			model.Id = value
-			return ctx, model, diagnostics
-		},
-		ResourceExistence: lucirpcglue.Required,
-		UpsertRequest: func(
-			ctx context.Context,
-			fullTypeName string,
-			options map[string]json.RawMessage,
-			model globalsModel,
-		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
-			ctx = logger.SetFieldString(ctx, fullTypeName, lucirpcglue.ResourceTerraformType, globalsIdAttribute, model.Id)
-			return ctx, options, diag.Diagnostics{}
-		},
-	}
-
 	globalsSchemaAttributes = map[string]lucirpcglue.SchemaAttribute[globalsModel, map[string]json.RawMessage, map[string]json.RawMessage]{
-		globalsIdAttribute:             globalsIdSchemaAttribute,
 		globalsULAPrefixAttribute:      globalsULAPrefixSchemaAttribute,
 		globalsPacketSteeringAttribute: globalsPacketSteeringSchemaAttribute,
+		lucirpcglue.IdAttribute:        lucirpcglue.IdSchemaAttribute(globalsModelGetId, globalsModelSetId),
 	}
 
 	globalsULAPrefixSchemaAttribute = lucirpcglue.StringSchemaAttribute[globalsModel, map[string]json.RawMessage, map[string]json.RawMessage]{
@@ -81,9 +49,11 @@ type globalsModel struct {
 	ULAPrefix      types.String `tfsdk:"ula_prefix"`
 }
 
+func globalsModelGetId(model globalsModel) types.String           { return model.Id }
 func globalsModelGetPacketSteering(model globalsModel) types.Bool { return model.PacketSteering }
 func globalsModelGetULAPrefix(model globalsModel) types.String    { return model.ULAPrefix }
 
+func globalsModelSetId(model *globalsModel, value types.String) { model.Id = value }
 func globalsModelSetPacketSteering(model *globalsModel, value types.Bool) {
 	model.PacketSteering = value
 }

--- a/openwrt/internal/network/globals_resource.go
+++ b/openwrt/internal/network/globals_resource.go
@@ -131,7 +131,7 @@ func (d *globalsResource) Delete(
 		return
 	}
 
-	ctx = logger.SetFieldString(ctx, d.fullTypeName, d.terraformType, globalsIdAttribute, model.Id)
+	ctx = logger.SetFieldString(ctx, d.fullTypeName, d.terraformType, lucirpcglue.IdAttribute, model.Id)
 	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", globalsUCIConfig, id))
 	tflog.Debug(ctx, "Deleting existing section")
@@ -154,7 +154,7 @@ func (d *globalsResource) ImportState(
 	res *resource.ImportStateResponse,
 ) {
 	tflog.Debug(ctx, "Retrieving import id and saving to id attribute")
-	resource.ImportStatePassthroughID(ctx, path.Root(globalsIdAttribute), req, res)
+	resource.ImportStatePassthroughID(ctx, path.Root(lucirpcglue.IdAttribute), req, res)
 }
 
 // Metadata sets the resource type name.

--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -1,12 +1,9 @@
 package system
 
 import (
-	"context"
 	"encoding/json"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
@@ -22,9 +19,6 @@ const (
 
 	systemHostnameAttribute = "hostname"
 	systemHostnameUCIOption = "hostname"
-
-	systemIdAttribute  = "id"
-	systemIdUCISection = ".name"
 
 	systemLogSizeAttribute = "log_size"
 	systemLogSizeUCIOption = "log_size"
@@ -77,32 +71,6 @@ var (
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(systemModelGetHostname, systemHostnameAttribute, systemHostnameUCIOption),
 	}
 
-	systemIdSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
-		DataSourceExistence: lucirpcglue.Required,
-		Description:         "Placeholder identifier attribute.",
-		ReadResponse: func(
-			ctx context.Context,
-			fullTypeName string,
-			terraformType string,
-			section map[string]json.RawMessage,
-			model systemModel,
-		) (context.Context, systemModel, diag.Diagnostics) {
-			ctx, value, diagnostics := lucirpcglue.GetMetadataString(ctx, fullTypeName, terraformType, section, systemIdUCISection)
-			model.Id = value
-			return ctx, model, diagnostics
-		},
-		ResourceExistence: lucirpcglue.Required,
-		UpsertRequest: func(
-			ctx context.Context,
-			fullTypeName string,
-			options map[string]json.RawMessage,
-			model systemModel,
-		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
-			ctx = logger.SetFieldString(ctx, fullTypeName, lucirpcglue.ResourceTerraformType, systemIdAttribute, model.Id)
-			return ctx, options, diag.Diagnostics{}
-		},
-	}
-
 	systemLogSizeSchemaAttribute = lucirpcglue.Int64SchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
 		Description:       "Size of the file based log buffer in KiB.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(systemModelSetLogSize, systemLogSizeAttribute, systemLogSizeUCIOption),
@@ -118,11 +86,11 @@ var (
 	}
 
 	systemSchemaAttributes = map[string]lucirpcglue.SchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+		lucirpcglue.IdAttribute:     lucirpcglue.IdSchemaAttribute(systemModelGetId, systemModelSetId),
 		systemConLogLevelAttribute:  systemConLogLevelSchemaAttribute,
 		systemCronLogLevelAttribute: systemCronLogLevelSchemaAttribute,
 		systemDescriptionAttribute:  systemDescriptionSchemaAttribute,
 		systemHostnameAttribute:     systemHostnameSchemaAttribute,
-		systemIdAttribute:           systemIdSchemaAttribute,
 		systemLogSizeAttribute:      systemLogSizeSchemaAttribute,
 		systemNotesAttribute:        systemNotesSchemaAttribute,
 		systemTimezoneAttribute:     systemTimezoneSchemaAttribute,
@@ -169,6 +137,7 @@ func systemModelGetConLogLevel(model systemModel) types.Int64  { return model.Co
 func systemModelGetCronLogLevel(model systemModel) types.Int64 { return model.CronLogLevel }
 func systemModelGetDescription(model systemModel) types.String { return model.Description }
 func systemModelGetHostname(model systemModel) types.String    { return model.Hostname }
+func systemModelGetId(model systemModel) types.String          { return model.Id }
 func systemModelGetLogSize(model systemModel) types.Int64      { return model.LogSize }
 func systemModelGetNotes(model systemModel) types.String       { return model.Notes }
 func systemModelGetTimezone(model systemModel) types.String    { return model.Timezone }
@@ -179,6 +148,7 @@ func systemModelSetConLogLevel(model *systemModel, value types.Int64)  { model.C
 func systemModelSetCronLogLevel(model *systemModel, value types.Int64) { model.CronLogLevel = value }
 func systemModelSetDescription(model *systemModel, value types.String) { model.Description = value }
 func systemModelSetHostname(model *systemModel, value types.String)    { model.Hostname = value }
+func systemModelSetId(model *systemModel, value types.String)          { model.Id = value }
 func systemModelSetLogSize(model *systemModel, value types.Int64)      { model.LogSize = value }
 func systemModelSetNotes(model *systemModel, value types.String)       { model.Notes = value }
 func systemModelSetTimezone(model *systemModel, value types.String)    { model.Timezone = value }

--- a/openwrt/internal/system/system_resource.go
+++ b/openwrt/internal/system/system_resource.go
@@ -131,7 +131,7 @@ func (d *systemResource) Delete(
 		return
 	}
 
-	ctx = logger.SetFieldString(ctx, d.fullTypeName, d.terraformType, systemIdAttribute, model.Id)
+	ctx = logger.SetFieldString(ctx, d.fullTypeName, d.terraformType, lucirpcglue.IdAttribute, model.Id)
 	id := model.Id.ValueString()
 	ctx = tflog.SetField(ctx, "section", fmt.Sprintf("%s.%s", systemUCIConfig, id))
 	tflog.Debug(ctx, "Deleting existing section")
@@ -154,7 +154,7 @@ func (d *systemResource) ImportState(
 	res *resource.ImportStateResponse,
 ) {
 	tflog.Debug(ctx, "Retrieving import id and saving to id attribute")
-	resource.ImportStatePassthroughID(ctx, path.Root(systemIdAttribute), req, res)
+	resource.ImportStatePassthroughID(ctx, path.Root(lucirpcglue.IdAttribute), req, res)
 }
 
 // Metadata sets the resource type name.


### PR DESCRIPTION
We seem to be doing the same thing for the id attribute everywhere.
Instead of copy/pasting this more (and to keep the ids consistent) we
pull this helper to a common location and use it in all the locations.