### PR TITLE
Abstract the behavior of Data Sources

### DIFF
--- a/openwrt/internal/lucirpcglue/data_source.go
+++ b/openwrt/internal/lucirpcglue/data_source.go
@@ -1,0 +1,133 @@
+package lucirpcglue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
+)
+
+var (
+	_ datasource.DataSource              = &dataSource[any]{}
+	_ datasource.DataSourceWithConfigure = &dataSource[any]{}
+)
+
+func NewDataSource[Model any](
+	getId func(Model) types.String,
+	schemaAttributes map[string]SchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage],
+	schemaDescription string,
+	uciConfig string,
+	uciType string,
+) datasource.DataSource {
+	return &dataSource[Model]{
+		getId:             getId,
+		schemaAttributes:  schemaAttributes,
+		schemaDescription: schemaDescription,
+		uciConfig:         uciConfig,
+		uciType:           uciType,
+	}
+}
+
+type dataSource[Model any] struct {
+	client            lucirpc.Client
+	fullTypeName      string
+	getId             func(Model) types.String
+	schemaAttributes  map[string]SchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage]
+	schemaDescription string
+	terraformType     string
+	uciConfig         string
+	uciType           string
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *dataSource[Model]) Configure(
+	ctx context.Context,
+	req datasource.ConfigureRequest,
+	res *datasource.ConfigureResponse,
+) {
+	tflog.Info(ctx, fmt.Sprintf("Configuring %s data source", d.fullTypeName))
+	if req.ProviderData == nil {
+		tflog.Debug(ctx, "No provider data")
+		return
+	}
+
+	client, diagnostics := NewClient(ConfigureRequest(req))
+	res.Diagnostics.Append(diagnostics...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	d.client = *client
+}
+
+// Metadata sets the data source name.
+func (d *dataSource[Model]) Metadata(
+	ctx context.Context,
+	req datasource.MetadataRequest,
+	res *datasource.MetadataResponse,
+) {
+	fullTypeName := fmt.Sprintf("%s_%s_%s", req.ProviderTypeName, d.uciConfig, d.uciType)
+	d.fullTypeName = fullTypeName
+	d.terraformType = DataSourceTerraformType
+	res.TypeName = fullTypeName
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *dataSource[Model]) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	res *datasource.ReadResponse,
+) {
+	tflog.Info(ctx, fmt.Sprintf("Reading %s data source", d.fullTypeName))
+
+	tflog.Debug(ctx, "Retrieving values from config")
+	var model Model
+	diagnostics := req.Config.Get(ctx, &model)
+	res.Diagnostics.Append(diagnostics...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, model, diagnostics = ReadModel(
+		ctx,
+		d.fullTypeName,
+		d.terraformType,
+		d.client,
+		d.schemaAttributes,
+		d.uciConfig,
+		d.getId(model).ValueString(),
+	)
+	res.Diagnostics.Append(diagnostics...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Setting the %s data source state", d.fullTypeName))
+	diagnostics = res.State.Set(ctx, model)
+	res.Diagnostics.Append(diagnostics...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Schema defines the schema for the data source.
+func (d *dataSource[Model]) Schema(
+	ctx context.Context,
+	req datasource.SchemaRequest,
+	res *datasource.SchemaResponse,
+) {
+	attributes := map[string]schema.Attribute{}
+	for k, v := range d.schemaAttributes {
+		attributes[k] = v.ToDataSource()
+	}
+
+	res.Schema = schema.Schema{
+		Attributes:  attributes,
+		Description: d.schemaDescription,
+	}
+}

--- a/openwrt/internal/network/device_data_source.go
+++ b/openwrt/internal/network/device_data_source.go
@@ -1,115 +1,16 @@
 package network
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
-var (
-	_ datasource.DataSource              = &deviceDataSource{}
-	_ datasource.DataSourceWithConfigure = &deviceDataSource{}
-)
-
 func NewDeviceDataSource() datasource.DataSource {
-	return &deviceDataSource{}
-}
-
-type deviceDataSource struct {
-	client        lucirpc.Client
-	fullTypeName  string
-	terraformType string
-}
-
-// Configure prepares the data source.
-func (d *deviceDataSource) Configure(
-	ctx context.Context,
-	req datasource.ConfigureRequest,
-	res *datasource.ConfigureResponse,
-) {
-	tflog.Info(ctx, fmt.Sprintf("Configuring %s Data Source", d.fullTypeName))
-	if req.ProviderData == nil {
-		tflog.Debug(ctx, "No provider data")
-		return
-	}
-
-	client, diagnostics := lucirpcglue.NewClient(lucirpcglue.ConfigureRequest(req))
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	d.client = *client
-}
-
-// Metadata sets the data source name.
-func (d *deviceDataSource) Metadata(
-	ctx context.Context,
-	req datasource.MetadataRequest,
-	res *datasource.MetadataResponse,
-) {
-	fullTypeName := fmt.Sprintf("%s_%s", req.ProviderTypeName, deviceTypeName)
-	d.fullTypeName = fullTypeName
-	d.terraformType = lucirpcglue.DataSourceTerraformType
-	res.TypeName = fullTypeName
-}
-
-// Read prepares the data source.
-func (d *deviceDataSource) Read(
-	ctx context.Context,
-	req datasource.ReadRequest,
-	res *datasource.ReadResponse,
-) {
-	tflog.Info(ctx, fmt.Sprintf("Reading %s data source", d.fullTypeName))
-
-	tflog.Debug(ctx, "Retrieving values from config")
-	var model deviceModel
-	diagnostics := req.Config.Get(ctx, &model)
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	ctx, model, diagnostics = lucirpcglue.ReadModel(
-		ctx,
-		d.fullTypeName,
-		d.terraformType,
-		d.client,
+	return lucirpcglue.NewDataSource(
+		deviceModelGetId,
 		deviceSchemaAttributes,
+		deviceSchemaDescription,
 		deviceUCIConfig,
-		model.Id.ValueString(),
+		deviceUCIType,
 	)
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	tflog.Debug(ctx, fmt.Sprintf("Setting the %s data source state", d.fullTypeName))
-	diagnostics = res.State.Set(ctx, model)
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-}
-
-// Schema prepares the data source.
-func (d *deviceDataSource) Schema(
-	ctx context.Context,
-	req datasource.SchemaRequest,
-	res *datasource.SchemaResponse,
-) {
-	attributes := map[string]schema.Attribute{}
-	for k, v := range deviceSchemaAttributes {
-		attributes[k] = v.ToDataSource()
-	}
-
-	res.Schema = schema.Schema{
-		Attributes:  attributes,
-		Description: deviceSchemaDescription,
-	}
 }

--- a/openwrt/internal/network/globals_data_source.go
+++ b/openwrt/internal/network/globals_data_source.go
@@ -1,115 +1,16 @@
 package network
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
-var (
-	_ datasource.DataSource              = &globalsDataSource{}
-	_ datasource.DataSourceWithConfigure = &globalsDataSource{}
-)
-
 func NewGlobalsDataSource() datasource.DataSource {
-	return &globalsDataSource{}
-}
-
-type globalsDataSource struct {
-	client        lucirpc.Client
-	fullTypeName  string
-	terraformType string
-}
-
-// Configure prepares the data source.
-func (d *globalsDataSource) Configure(
-	ctx context.Context,
-	req datasource.ConfigureRequest,
-	res *datasource.ConfigureResponse,
-) {
-	tflog.Info(ctx, fmt.Sprintf("Configuring %s Data Source", d.fullTypeName))
-	if req.ProviderData == nil {
-		tflog.Debug(ctx, "No provider data")
-		return
-	}
-
-	client, diagnostics := lucirpcglue.NewClient(lucirpcglue.ConfigureRequest(req))
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	d.client = *client
-}
-
-// Metadata sets the data source name.
-func (d *globalsDataSource) Metadata(
-	ctx context.Context,
-	req datasource.MetadataRequest,
-	res *datasource.MetadataResponse,
-) {
-	fullTypeName := fmt.Sprintf("%s_%s", req.ProviderTypeName, globalsTypeName)
-	d.fullTypeName = fullTypeName
-	d.terraformType = lucirpcglue.DataSourceTerraformType
-	res.TypeName = fullTypeName
-}
-
-// Read prepares the data source.
-func (d *globalsDataSource) Read(
-	ctx context.Context,
-	req datasource.ReadRequest,
-	res *datasource.ReadResponse,
-) {
-	tflog.Info(ctx, fmt.Sprintf("Reading %s data source", d.fullTypeName))
-
-	tflog.Debug(ctx, "Retrieving values from config")
-	var model globalsModel
-	diagnostics := req.Config.Get(ctx, &model)
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	ctx, model, diagnostics = lucirpcglue.ReadModel(
-		ctx,
-		d.fullTypeName,
-		d.terraformType,
-		d.client,
+	return lucirpcglue.NewDataSource(
+		globalsModelGetId,
 		globalsSchemaAttributes,
+		globalsSchemaDescription,
 		globalsUCIConfig,
-		model.Id.ValueString(),
+		globalsUCIGlobalsType,
 	)
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	tflog.Debug(ctx, fmt.Sprintf("Setting the %s data source state", d.fullTypeName))
-	diagnostics = res.State.Set(ctx, model)
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-}
-
-// Schema prepares the data source.
-func (d *globalsDataSource) Schema(
-	ctx context.Context,
-	req datasource.SchemaRequest,
-	res *datasource.SchemaResponse,
-) {
-	attributes := map[string]schema.Attribute{}
-	for k, v := range globalsSchemaAttributes {
-		attributes[k] = v.ToDataSource()
-	}
-
-	res.Schema = schema.Schema{
-		Attributes:  attributes,
-		Description: globalsSchemaDescription,
-	}
 }

--- a/openwrt/internal/system/system_data_source.go
+++ b/openwrt/internal/system/system_data_source.go
@@ -1,115 +1,16 @@
 package system
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
-var (
-	_ datasource.DataSource              = &systemDataSource{}
-	_ datasource.DataSourceWithConfigure = &systemDataSource{}
-)
-
 func NewSystemDataSource() datasource.DataSource {
-	return &systemDataSource{}
-}
-
-type systemDataSource struct {
-	client        lucirpc.Client
-	fullTypeName  string
-	terraformType string
-}
-
-// Configure prepares the data source.
-func (d *systemDataSource) Configure(
-	ctx context.Context,
-	req datasource.ConfigureRequest,
-	res *datasource.ConfigureResponse,
-) {
-	tflog.Info(ctx, fmt.Sprintf("Configuring %s Data Source", d.fullTypeName))
-	if req.ProviderData == nil {
-		tflog.Debug(ctx, "No provider data")
-		return
-	}
-
-	client, diagnostics := lucirpcglue.NewClient(lucirpcglue.ConfigureRequest(req))
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	d.client = *client
-}
-
-// Metadata sets the data source name.
-func (d *systemDataSource) Metadata(
-	ctx context.Context,
-	req datasource.MetadataRequest,
-	res *datasource.MetadataResponse,
-) {
-	fullTypeName := fmt.Sprintf("%s_%s", req.ProviderTypeName, systemTypeName)
-	d.fullTypeName = fullTypeName
-	d.terraformType = lucirpcglue.DataSourceTerraformType
-	res.TypeName = fullTypeName
-}
-
-// Read prepares the data source.
-func (d *systemDataSource) Read(
-	ctx context.Context,
-	req datasource.ReadRequest,
-	res *datasource.ReadResponse,
-) {
-	tflog.Info(ctx, fmt.Sprintf("Reading %s data source", d.fullTypeName))
-
-	tflog.Debug(ctx, "Retrieving values from config")
-	var model systemModel
-	diagnostics := req.Config.Get(ctx, &model)
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	ctx, model, diagnostics = lucirpcglue.ReadModel(
-		ctx,
-		d.fullTypeName,
-		d.terraformType,
-		d.client,
+	return lucirpcglue.NewDataSource(
+		systemModelGetId,
 		systemSchemaAttributes,
+		systemSchemaDescription,
 		systemUCIConfig,
-		model.Id.ValueString(),
+		systemUCISystemType,
 	)
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-
-	tflog.Debug(ctx, fmt.Sprintf("Setting the %s data source state", d.fullTypeName))
-	diagnostics = res.State.Set(ctx, model)
-	res.Diagnostics.Append(diagnostics...)
-	if res.Diagnostics.HasError() {
-		return
-	}
-}
-
-// Schema prepares the data source.
-func (d *systemDataSource) Schema(
-	ctx context.Context,
-	req datasource.SchemaRequest,
-	res *datasource.SchemaResponse,
-) {
-	attributes := map[string]schema.Attribute{}
-	for k, v := range systemSchemaAttributes {
-		attributes[k] = v.ToDataSource()
-	}
-
-	res.Schema = schema.Schema{
-		Attributes:  attributes,
-		Description: systemSchemaDescription,
-	}
 }


### PR DESCRIPTION
Since all of the Data Sources are doing the same stuff, we pull out the
behavior to a common location that we can use in multiple places. We
then initialize it with the pieces that are different: a getter for the
id, the schema stuff, and the UCI stuff.

Then, we can simplify the actual Data Sources to almost nothing. We
still keep them around because testing their behavior is different for
each one. But this might be as minimal as we can get things.