### PR TITLE
Remove provider and output for examples

### DIFF
--- a/docs/data-sources/network_device.md
+++ b/docs/data-sources/network_device.md
@@ -13,17 +13,8 @@ A physical or virtual "device" in OpenWrt jargon. Commonly referred to as an "in
 ## Example Usage
 
 ```terraform
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 data "openwrt_network_device" "br_testing" {
   id = "br_testing"
-}
-
-output "network_device_br_testing" {
-  value = data.openwrt_network_device.br_testing
 }
 ```
 

--- a/docs/data-sources/network_globals.md
+++ b/docs/data-sources/network_globals.md
@@ -13,17 +13,8 @@ Contains interface-independent options affecting the network configuration in ge
 ## Example Usage
 
 ```terraform
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 data "openwrt_network_globals" "this" {
   id = "globals"
-}
-
-output "network_globals" {
-  value = data.openwrt_network_globals.this
 }
 ```
 

--- a/docs/data-sources/system_system.md
+++ b/docs/data-sources/system_system.md
@@ -13,17 +13,8 @@ Provides system data about an OpenWrt device
 ## Example Usage
 
 ```terraform
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 data "openwrt_system_system" "this" {
   id = "cfg01e48a"
-}
-
-output "system_system" {
-  value = data.openwrt_system_system.this
 }
 ```
 

--- a/docs/resources/network_device.md
+++ b/docs/resources/network_device.md
@@ -13,11 +13,6 @@ A physical or virtual "device" in OpenWrt jargon. Commonly referred to as an "in
 ## Example Usage
 
 ```terraform
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 resource "openwrt_network_device" "br_testing" {
   id   = "br_testing"
   name = "br-testing"
@@ -27,10 +22,6 @@ resource "openwrt_network_device" "br_testing" {
     "eth2.20",
   ]
   type = "bridge"
-}
-
-output "network_device_br_testing" {
-  value = resource.openwrt_network_device.br_testing
 }
 ```
 

--- a/docs/resources/network_globals.md
+++ b/docs/resources/network_globals.md
@@ -13,19 +13,10 @@ Contains interface-independent options affecting the network configuration in ge
 ## Example Usage
 
 ```terraform
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 resource "openwrt_network_globals" "this" {
   id              = "globals"
   packet_steering = false
   ula_prefix      = "fd12:3456:789a::/48"
-}
-
-output "network_globals" {
-  value = resource.openwrt_network_globals.this
 }
 ```
 

--- a/docs/resources/system_system.md
+++ b/docs/resources/system_system.md
@@ -13,19 +13,10 @@ Provides system data about an OpenWrt device
 ## Example Usage
 
 ```terraform
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 resource "openwrt_system_system" "this" {
   hostname = "OpenWrt"
   id       = "cfg01e48a"
   zonename = "America/Los Angeles"
-}
-
-output "system_system" {
-  value = resource.openwrt_system_system.this
 }
 ```
 

--- a/examples/data-sources/openwrt_network_device/data-source.tf
+++ b/examples/data-sources/openwrt_network_device/data-source.tf
@@ -1,12 +1,3 @@
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 data "openwrt_network_device" "br_testing" {
   id = "br_testing"
-}
-
-output "network_device_br_testing" {
-  value = data.openwrt_network_device.br_testing
 }

--- a/examples/data-sources/openwrt_network_globals/data-source.tf
+++ b/examples/data-sources/openwrt_network_globals/data-source.tf
@@ -1,12 +1,3 @@
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 data "openwrt_network_globals" "this" {
   id = "globals"
-}
-
-output "network_globals" {
-  value = data.openwrt_network_globals.this
 }

--- a/examples/data-sources/openwrt_system_system/data-source.tf
+++ b/examples/data-sources/openwrt_system_system/data-source.tf
@@ -1,12 +1,3 @@
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 data "openwrt_system_system" "this" {
   id = "cfg01e48a"
-}
-
-output "system_system" {
-  value = data.openwrt_system_system.this
 }

--- a/examples/resources/openwrt_network_device/resource.tf
+++ b/examples/resources/openwrt_network_device/resource.tf
@@ -1,8 +1,3 @@
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 resource "openwrt_network_device" "br_testing" {
   id   = "br_testing"
   name = "br-testing"
@@ -12,8 +7,4 @@ resource "openwrt_network_device" "br_testing" {
     "eth2.20",
   ]
   type = "bridge"
-}
-
-output "network_device_br_testing" {
-  value = resource.openwrt_network_device.br_testing
 }

--- a/examples/resources/openwrt_network_globals/resource.tf
+++ b/examples/resources/openwrt_network_globals/resource.tf
@@ -1,14 +1,5 @@
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 resource "openwrt_network_globals" "this" {
   id              = "globals"
   packet_steering = false
   ula_prefix      = "fd12:3456:789a::/48"
-}
-
-output "network_globals" {
-  value = resource.openwrt_network_globals.this
 }

--- a/examples/resources/openwrt_system_system/resource.tf
+++ b/examples/resources/openwrt_system_system/resource.tf
@@ -1,14 +1,5 @@
-provider "openwrt" {
-  hostname = "localhost"
-  port     = 8080
-}
-
 resource "openwrt_system_system" "this" {
   hostname = "OpenWrt"
   id       = "cfg01e48a"
   zonename = "America/Los Angeles"
-}
-
-output "system_system" {
-  value = resource.openwrt_system_system.this
 }


### PR DESCRIPTION
We should probably be keeping each of these examples to the minimum so
it's clearer what someone needs to do to setup one of these Data Sources
or Resources.