### PR TITLE
Relax provider's dependency on environment

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -19,7 +20,7 @@ const (
 func main() {
 	ctx := context.Background()
 	providerNew := func() provider.Provider {
-		return openwrt.New(version)
+		return openwrt.New(version, os.LookupEnv)
 	}
 	options := providerserver.ServeOpts{
 		Address: "registry.terraform.io/joneshf/openwrt",

--- a/openwrt/internal/network/device_data_source_acceptance_test.go
+++ b/openwrt/internal/network/device_data_source_acceptance_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -40,7 +41,7 @@ func TestNetworkDeviceDataSourceAcceptance(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
 		},
 		Steps: []resource.TestStep{
 			{

--- a/openwrt/internal/network/device_resource_acceptance_test.go
+++ b/openwrt/internal/network/device_resource_acceptance_test.go
@@ -5,6 +5,7 @@ package network_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -107,7 +108,7 @@ resource "openwrt_network_device" "br_testing" {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
 		},
 		Steps: []resource.TestStep{
 			createAndReadTestStep,

--- a/openwrt/internal/network/globals_data_source_acceptance_test.go
+++ b/openwrt/internal/network/globals_data_source_acceptance_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -39,7 +40,7 @@ func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
 		},
 		Steps: []resource.TestStep{
 			{

--- a/openwrt/internal/network/globals_resource_acceptance_test.go
+++ b/openwrt/internal/network/globals_resource_acceptance_test.go
@@ -5,6 +5,7 @@ package network_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -83,7 +84,7 @@ resource "openwrt_network_globals" "this" {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
 		},
 		Steps: []resource.TestStep{
 			createAndReadTestStep,

--- a/openwrt/internal/system/system_data_source_acceptance_test.go
+++ b/openwrt/internal/system/system_data_source_acceptance_test.go
@@ -5,6 +5,7 @@ package system_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -27,7 +28,7 @@ func TestSystemSystemDataSourceAcceptance(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
 		},
 		Steps: []resource.TestStep{
 			{

--- a/openwrt/internal/system/system_resource_acceptance_test.go
+++ b/openwrt/internal/system/system_resource_acceptance_test.go
@@ -5,6 +5,7 @@ package system_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -89,7 +90,7 @@ resource "openwrt_system_system" "this" {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test")),
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
 		},
 		Steps: []resource.TestStep{
 			createAndReadTestStep,

--- a/openwrt/provider_acceptance_test.go
+++ b/openwrt/provider_acceptance_test.go
@@ -56,7 +56,7 @@ func TestOpenWrtProviderConfigureConnectsWithoutError(t *testing.T) {
 		t,
 	)
 	defer openWrt.Close()
-	openWrtProvider := openwrt.New("test")
+	openWrtProvider := openwrt.New("test", os.LookupEnv)
 	schemaReq := provider.SchemaRequest{}
 	schemaRes := &provider.SchemaResponse{}
 	openWrtProvider.Schema(ctx, schemaReq, schemaRes)

--- a/openwrt/provider_test.go
+++ b/openwrt/provider_test.go
@@ -2,6 +2,7 @@ package openwrt_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -13,7 +14,7 @@ import (
 func TestOpenWrtProviderMetadataDoesNotSetVersion(t *testing.T) {
 	// Given
 	ctx := context.Background()
-	openWrtProvider := openwrt.New("test")
+	openWrtProvider := openwrt.New("test", os.LookupEnv)
 	req := provider.MetadataRequest{}
 	res := &provider.MetadataResponse{}
 
@@ -27,7 +28,7 @@ func TestOpenWrtProviderMetadataDoesNotSetVersion(t *testing.T) {
 func TestOpenWrtProviderMetadataSetsTypeName(t *testing.T) {
 	// Given
 	ctx := context.Background()
-	openWrtProvider := openwrt.New("test")
+	openWrtProvider := openwrt.New("test", os.LookupEnv)
 	req := provider.MetadataRequest{}
 	res := &provider.MetadataResponse{}
 
@@ -72,7 +73,7 @@ func TestOpenWrtProviderSchemaUsernameAttribute(t *testing.T) {
 func TestOpenWrtProviderSchemaDoesNotUseInvalidAttributes(t *testing.T) {
 	// Given
 	ctx := context.Background()
-	openWrtProvider := openwrt.New("test")
+	openWrtProvider := openwrt.New("test", os.LookupEnv)
 	req := provider.SchemaRequest{}
 	res := &provider.SchemaResponse{}
 	openWrtProvider.Schema(ctx, req, res)
@@ -92,7 +93,7 @@ func schemaAttributeExists(
 
 		// Given
 		ctx := context.Background()
-		openWrtProvider := openwrt.New("test")
+		openWrtProvider := openwrt.New("test", os.LookupEnv)
 		req := provider.SchemaRequest{}
 		res := &provider.SchemaResponse{}
 
@@ -113,7 +114,7 @@ func schemaAttributeIsOptional(
 
 		// Given
 		ctx := context.Background()
-		openWrtProvider := openwrt.New("test")
+		openWrtProvider := openwrt.New("test", os.LookupEnv)
 		req := provider.SchemaRequest{}
 		res := &provider.SchemaResponse{}
 
@@ -134,7 +135,7 @@ func schemaAttributeIsSensitive(
 
 		// Given
 		ctx := context.Background()
-		openWrtProvider := openwrt.New("test")
+		openWrtProvider := openwrt.New("test", os.LookupEnv)
 		req := provider.SchemaRequest{}
 		res := &provider.SchemaResponse{}
 


### PR DESCRIPTION
We do want to support reading default values from the environment, but
we don't need to have a hard dependency on using the actual environment
in the provider's implementation. Instead, we can describe what
dependency we actually have (looking up a value in the environment) and
let the callers pass their version of the dependency in.

This really doesn't do much at the moment, but it paves the way for
writing a test that can still run in parallel even though it's doing
things to the "environment." We'll add that test in the future.