### PR TITLE
Fix port lookup in the environment

### DIFF
--- a/openwrt/provider.go
+++ b/openwrt/provider.go
@@ -289,7 +289,7 @@ func defaultInt64AttributeValue(
 	variable, ok := lookupEnv(environmentVariable)
 	if ok {
 		parsed, err := strconv.Atoi(variable)
-		if err != nil {
+		if err == nil {
 			value = int64(parsed)
 		}
 	}


### PR DESCRIPTION
We had the boolean flipped when deciding whether or not to use the
parsed value. We flip it the other way, so it should work properly now.

This is another example of how having sum types would have prevented the
bug from even happening in the first place. If we could represent the
result of `strconv.Atoi` as a sum of `int` or `error` (rather than a
product of both `int` and `error`), we wouldn't have needed to check
whether an `error` was `nil` or not. In fact, if sum types permeated
through the language more, we likely wouldn't even have `nil` as a
possible value of `error` to check in the first place. In any case, sums
could've prevented another bug.