### PR TITLE
Use a more specific cache for nix stuff

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,11 @@ jobs:
       - name: Cache Nix
         uses: actions/cache@v3.3.0
         with:
-          key: ${{ runner.os }}-${{ hashfiles('flake.nix') }}
+          key: ${{ runner.os }}-nix-${{ hashfiles('flake.nix') }}
           path: ~/nix
+          restore-keys: |
+            ${{ runner.os }}-nix-${{ hashfiles('flake.nix') }}
+            ${{ runner.os }}-nix-
       - name: Import GPG
         uses: crazy-max/ghaction-import-gpg@v5.2.0
         id: import_gpg

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,10 +24,10 @@ jobs:
       - name: Cache Nix
         uses: actions/cache@v3.3.0
         with:
-          key: ${{ runner.os }}-nix-${{ hashfiles('flake.nix') }}
+          key: ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
           path: ~/nix
           restore-keys: |
-            ${{ runner.os }}-nix-${{ hashfiles('flake.nix') }}
+            ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
             ${{ runner.os }}-nix-
       - name: Import GPG
         uses: crazy-max/ghaction-import-gpg@v5.2.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,10 @@ jobs:
       - name: Cache Nix
         uses: actions/cache@v3.3.0
         with:
-          key: ${{ runner.os }}-${{ hashfiles('flake.nix') }}
+          key: ${{ runner.os }}-nix-${{ hashfiles('flake.nix') }}
           path: ~/nix
+          restore-keys: |
+            ${{ runner.os }}-nix-${{ hashfiles('flake.nix') }}
+            ${{ runner.os }}-nix-
       - name: Test
         run: nix --store ~/nix develop . --command make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,10 +16,10 @@ jobs:
       - name: Cache Nix
         uses: actions/cache@v3.3.0
         with:
-          key: ${{ runner.os }}-nix-${{ hashfiles('flake.nix') }}
+          key: ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
           path: ~/nix
           restore-keys: |
-            ${{ runner.os }}-nix-${{ hashfiles('flake.nix') }}
+            ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
             ${{ runner.os }}-nix-
       - name: Test
         run: nix --store ~/nix develop . --command make test


### PR DESCRIPTION
Before we add a cache for other things, we should be a little more
specific with the nix cache. We toss the word `nix` into the key, so
we're less likely to conflict with other stuff.

We also make the restore keys fallback to the closest cache they can
find. We don't want to have to redo everything if a cache miss happens
because we added or removed a single dependency.