### PR TITLE
Cache `go` stuff

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
             ${{ runner.os }}-nix-
+      - name: Cache Go
+        uses: actions/cache@v3.3.0
+        with:
+          # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
+          key: ${{ runner.os }}-go-${{ hashfiles('go.mod', 'go.sum') }}
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashfiles('go.mod', 'go.sum') }}
+            ${{ runner.os }}-go-
       - name: Import GPG
         uses: crazy-max/ghaction-import-gpg@v5.2.0
         id: import_gpg

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,5 +21,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
             ${{ runner.os }}-nix-
+      - name: Cache Go
+        uses: actions/cache@v3.3.0
+        with:
+          # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
+          key: ${{ runner.os }}-go-${{ hashfiles('go.mod', 'go.sum') }}
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashfiles('go.mod', 'go.sum') }}
+            ${{ runner.os }}-go-
       - name: Test
         run: nix --store ~/nix develop . --command make test


### PR DESCRIPTION
We follow what we're doing for `nix` and cache the dependencies and
build artifacts for `go`.

We end up having to use `go.mod` as a hash as well because it is the
only place we have the go version written down anywhere, and we want
that to be part of the cache invalidation strategy.

This change shaves a large chunk off CI time. For posterity, the first
commit here was 3m 9s. The second commit here was 1m 29s. That's more
than 50% of the CI!