### PR TITLE
Cache `docker` image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,5 +32,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ hashfiles('go.mod', 'go.sum') }}
             ${{ runner.os }}-go-
+      - name: Cache Docker Image
+        uses: actions/cache@v3.3.0
+        with:
+          key: ${{ runner.os }}-docker-${{ hashfiles('acceptance-test.Dockerfile', 'acceptance-test.Dockerfile.dockerignore') }}
+          path: .cache/docker
+          restore-keys: |
+            ${{ runner.os }}-docker-${{ hashfiles('acceptance-test.Dockerfile', 'acceptance-test.Dockerfile.dockerignore') }}
+            ${{ runner.os }}-docker-
       - name: Test
         run: nix --store ~/nix develop . --command make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### Project-specific ###
 .direnv
+.cache
 
 ### DO NOT EDIT ANYTHING BELOW HERE BY HAND; REGNERATE IT AT THE EDIT LINK.
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ Makefile:;
 
 ACCEPTANCE_TEST_BUILD_CONSTRAINT := acceptance.test
 ACCEPTANCE_TEST_DOCKER_COMPOSE_FILE := ./docker-compose.acceptance-test.yaml
+CACHE_DIRECTORY := .cache
 
 .DEFAULT_GOAL := test
 
@@ -11,11 +12,15 @@ build:
 	go build ./...
 
 .PHONY: clean
-clean: clean-acceptance-test-server
+clean: clean-acceptance-test-server clean-cache-directory
 
 .PHONY: clean-acceptance-test-server
 clean-acceptance-test-server:
 	docker compose --file $(ACCEPTANCE_TEST_DOCKER_COMPOSE_FILE) down --remove-orphans --rmi all --volumes
+
+.PHONY: clean-cache-directory
+clean-cache-directory:
+	rm -fr $(CACHE_DIRECTORY)
 
 .PHONY: docs
 docs: install


### PR DESCRIPTION
This seems to be the last big thing for caching. We seem to be
rebuilding this image each time in CI. That's not the worst thing
(because `docker` caching is actually more complex than most people
would admit) but it does mean that we're spending a lot of time building
effectively the same thing.

We opt to make a cache of the image tar in a local directory, and use
that in CI. It's possible that we're going to regret this decision later
when we have troubles invalidating the cache. But we'll roll with this
for a bit, and see how it goes.

For posterity, the first commit in this change clocked in at 2m 17s; the
second commit with the cache hit clocked in at 1m 56s. A savings of 15%!