### PR TITLE
Only return a teardown func

### DIFF
--- a/internal/acceptancetest/helpers.go
+++ b/internal/acceptancetest/helpers.go
@@ -122,17 +122,17 @@ func Setup(
 	return
 }
 
-// AuthenticatedClient constructs a running [*dockertest.Resource] representing an OpenWrt server, and [*lucirpc.Client].
-// [dockertest.Resource.Close] must be called on the returned [*dockertest.Resource].
+// AuthenticatedClient constructs a running OpenWrt server, and [*lucirpc.Client].
+// The tearDown function must be called after finishing with the client.
 // The [*lucirpc.Client] can be used to interact with the underlying OpenWrt server.
 func AuthenticatedClient(
 	ctx context.Context,
 	dockerPool dockertest.Pool,
 	t *testing.T,
-) (*dockertest.Resource, *lucirpc.Client) {
+) (tearDown func(), client *lucirpc.Client) {
 	t.Helper()
 
-	openWrt, host, port := RunOpenWrtServer(ctx, dockerPool, t)
+	tearDown, host, port := RunOpenWrtServer(ctx, dockerPool, t)
 	client, err := lucirpc.NewClient(
 		ctx,
 		Scheme,
@@ -142,8 +142,7 @@ func AuthenticatedClient(
 		Password,
 	)
 	assert.NilError(t, err)
-
-	return openWrt, client
+	return
 }
 
 func checkHealth(
@@ -166,19 +165,25 @@ func checkHealth(
 	}
 }
 
-// RunOpenWrtServer constructs a running [*dockertest.Resource] representing an OpenWrt server.
-// [dockertest.Resource.Close] must be called on the returned [*dockertest.Resource].
+// RunOpenWrtServer constructs a running OpenWrt server.
+// The tearDown function must be called after finishing with the client.
 // The hostname and port can be arbitrary,
 // so they are returned to make it easier to interact with the OpenWrt server.
 func RunOpenWrtServer(
 	ctx context.Context,
 	dockerPool dockertest.Pool,
 	t *testing.T,
-) (openWrt *dockertest.Resource, hostname string, port uint16) {
+) (tearDown func(), hostname string, port uint16) {
 	t.Helper()
 
 	openWrt, err := dockerPool.Run(acceptanceTestDockerName, acceptanceTestDockerTag, []string{})
 	assert.NilError(t, err)
+	tearDown = func() {
+		t.Helper()
+
+		err = openWrt.Close()
+		assert.NilError(t, err)
+	}
 	err = openWrt.Expire(60)
 	assert.NilError(t, err)
 	err = dockerPool.Retry(checkHealth(ctx, dockerPool, *openWrt))

--- a/lucirpc/client_acceptance_test.go
+++ b/lucirpc/client_acceptance_test.go
@@ -28,12 +28,12 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 
 		// When
 		got, err := client.CreateSection(
@@ -54,12 +54,12 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 
 		// When
 		got, err := client.CreateSection(
@@ -80,12 +80,12 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 
 		// When
 		_, err := client.CreateSection(
@@ -123,12 +123,12 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 
 		// When
 		_, err := client.CreateSection(
@@ -158,12 +158,12 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 
 		// When
 		got, err := client.DeleteSection(
@@ -182,12 +182,12 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -214,12 +214,12 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -251,12 +251,12 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -292,12 +292,12 @@ func TestClientGetSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 
 		// When
 		_, err := client.GetSection(
@@ -315,12 +315,12 @@ func TestClientGetSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 
 		// When
 		got, err := client.GetSection(
@@ -375,8 +375,8 @@ func TestNewClientAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, hostname, port := acceptancetest.RunOpenWrtServer(ctx, *dockerPool, t)
-		defer openWrt.Close()
+		tearDown, hostname, port := acceptancetest.RunOpenWrtServer(ctx, *dockerPool, t)
+		defer tearDown()
 
 		// When
 		_, err := lucirpc.NewClient(
@@ -401,12 +401,12 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 
 		// When
 		got, err := client.UpdateSection(
@@ -426,12 +426,12 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -459,12 +459,12 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -494,12 +494,12 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -544,12 +544,12 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		openWrt, client := acceptancetest.AuthenticatedClient(
+		tearDown, client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer openWrt.Close()
+		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",

--- a/openwrt/internal/network/device_data_source_acceptance_test.go
+++ b/openwrt/internal/network/device_data_source_acceptance_test.go
@@ -22,12 +22,12 @@ func TestNetworkDeviceDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
+	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer openWrt.Close()
+	defer tearDown()
 	client, err := lucirpc.NewClient(ctx, acceptancetest.Scheme, hostname, port, acceptancetest.Username, acceptancetest.Password)
 	assert.NilError(t, err)
 	options := map[string]json.RawMessage{

--- a/openwrt/internal/network/device_resource_acceptance_test.go
+++ b/openwrt/internal/network/device_resource_acceptance_test.go
@@ -19,12 +19,12 @@ func TestNetworkDeviceResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
+	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer openWrt.Close()
+	defer tearDown()
 
 	createAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/internal/network/globals_data_source_acceptance_test.go
+++ b/openwrt/internal/network/globals_data_source_acceptance_test.go
@@ -22,12 +22,12 @@ func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
+	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer openWrt.Close()
+	defer tearDown()
 	client, err := lucirpc.NewClient(ctx, acceptancetest.Scheme, hostname, port, acceptancetest.Username, acceptancetest.Password)
 	assert.NilError(t, err)
 	options := map[string]json.RawMessage{

--- a/openwrt/internal/network/globals_resource_acceptance_test.go
+++ b/openwrt/internal/network/globals_resource_acceptance_test.go
@@ -19,12 +19,12 @@ func TestNetworkGlobalsResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
+	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer openWrt.Close()
+	defer tearDown()
 
 	createAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/internal/system/system_data_source_acceptance_test.go
+++ b/openwrt/internal/system/system_data_source_acceptance_test.go
@@ -19,12 +19,12 @@ func TestSystemSystemDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
+	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer openWrt.Close()
+	defer tearDown()
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){

--- a/openwrt/internal/system/system_resource_acceptance_test.go
+++ b/openwrt/internal/system/system_resource_acceptance_test.go
@@ -19,12 +19,12 @@ func TestSystemSystemResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
+	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer openWrt.Close()
+	defer tearDown()
 
 	createAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/provider_acceptance_test.go
+++ b/openwrt/provider_acceptance_test.go
@@ -51,12 +51,12 @@ func TestOpenWrtProviderConfigureConnectsWithoutError(t *testing.T) {
 
 	// Given
 	ctx := context.Background()
-	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
+	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer openWrt.Close()
+	defer tearDown()
 	openWrtProvider := openwrt.New("test", os.LookupEnv)
 	schemaReq := provider.SchemaRequest{}
 	schemaRes := &provider.SchemaResponse{}
@@ -99,12 +99,12 @@ func TestOpenWrtProviderConfigureConnectsWithoutErrorWithEnvironmentVariables(t 
 
 	// Given
 	ctx := context.Background()
-	openWrt, hostname, port := acceptancetest.RunOpenWrtServer(
+	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer openWrt.Close()
+	defer tearDown()
 	env := map[string]string{
 		"OPENWRT_HOSTNAME": hostname,
 		"OPENWRT_PASSWORD": acceptancetest.Password,


### PR DESCRIPTION
We don't need to expose a full `*dockertest.Resource` when all we do is
close it after the test is over. Instead, we can just pass a "teardown"
func to invoke once we're done.