### PR TITLE
Use `testing.T.Cleanup`

### DIFF
--- a/lucirpc/client_acceptance_test.go
+++ b/lucirpc/client_acceptance_test.go
@@ -28,12 +28,11 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 
 		// When
 		got, err := client.CreateSection(
@@ -54,12 +53,11 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 
 		// When
 		got, err := client.CreateSection(
@@ -80,12 +78,11 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 
 		// When
 		_, err := client.CreateSection(
@@ -123,12 +120,11 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 
 		// When
 		_, err := client.CreateSection(
@@ -158,12 +154,11 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 
 		// When
 		got, err := client.DeleteSection(
@@ -182,12 +177,11 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -214,12 +208,11 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -251,12 +244,11 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -292,12 +284,11 @@ func TestClientGetSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 
 		// When
 		_, err := client.GetSection(
@@ -315,12 +306,11 @@ func TestClientGetSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 
 		// When
 		got, err := client.GetSection(
@@ -375,8 +365,7 @@ func TestNewClientAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, hostname, port := acceptancetest.RunOpenWrtServer(ctx, *dockerPool, t)
-		defer tearDown()
+		hostname, port := acceptancetest.RunOpenWrtServer(ctx, *dockerPool, t)
 
 		// When
 		_, err := lucirpc.NewClient(
@@ -401,12 +390,11 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 
 		// When
 		got, err := client.UpdateSection(
@@ -426,12 +414,11 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -459,12 +446,11 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -494,12 +480,11 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",
@@ -544,12 +529,11 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		tearDown, client := acceptancetest.AuthenticatedClient(
+		client := acceptancetest.AuthenticatedClient(
 			ctx,
 			*dockerPool,
 			t,
 		)
-		defer tearDown()
 		_, err := client.CreateSection(
 			ctx,
 			"network",

--- a/openwrt/internal/network/device_data_source_acceptance_test.go
+++ b/openwrt/internal/network/device_data_source_acceptance_test.go
@@ -22,12 +22,11 @@ func TestNetworkDeviceDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
+	hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer tearDown()
 	client, err := lucirpc.NewClient(ctx, acceptancetest.Scheme, hostname, port, acceptancetest.Username, acceptancetest.Password)
 	assert.NilError(t, err)
 	options := map[string]json.RawMessage{

--- a/openwrt/internal/network/device_resource_acceptance_test.go
+++ b/openwrt/internal/network/device_resource_acceptance_test.go
@@ -19,12 +19,11 @@ func TestNetworkDeviceResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
+	hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer tearDown()
 
 	createAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/internal/network/globals_data_source_acceptance_test.go
+++ b/openwrt/internal/network/globals_data_source_acceptance_test.go
@@ -22,12 +22,11 @@ func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
+	hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer tearDown()
 	client, err := lucirpc.NewClient(ctx, acceptancetest.Scheme, hostname, port, acceptancetest.Username, acceptancetest.Password)
 	assert.NilError(t, err)
 	options := map[string]json.RawMessage{

--- a/openwrt/internal/network/globals_resource_acceptance_test.go
+++ b/openwrt/internal/network/globals_resource_acceptance_test.go
@@ -19,12 +19,11 @@ func TestNetworkGlobalsResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
+	hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer tearDown()
 
 	createAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/internal/system/system_data_source_acceptance_test.go
+++ b/openwrt/internal/system/system_data_source_acceptance_test.go
@@ -19,12 +19,11 @@ func TestSystemSystemDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
+	hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer tearDown()
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){

--- a/openwrt/internal/system/system_resource_acceptance_test.go
+++ b/openwrt/internal/system/system_resource_acceptance_test.go
@@ -19,12 +19,11 @@ func TestSystemSystemResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
+	hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer tearDown()
 
 	createAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/provider_acceptance_test.go
+++ b/openwrt/provider_acceptance_test.go
@@ -51,12 +51,11 @@ func TestOpenWrtProviderConfigureConnectsWithoutError(t *testing.T) {
 
 	// Given
 	ctx := context.Background()
-	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
+	hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer tearDown()
 	openWrtProvider := openwrt.New("test", os.LookupEnv)
 	schemaReq := provider.SchemaRequest{}
 	schemaRes := &provider.SchemaResponse{}
@@ -99,12 +98,11 @@ func TestOpenWrtProviderConfigureConnectsWithoutErrorWithEnvironmentVariables(t 
 
 	// Given
 	ctx := context.Background()
-	tearDown, hostname, port := acceptancetest.RunOpenWrtServer(
+	hostname, port := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	defer tearDown()
 	env := map[string]string{
 		"OPENWRT_HOSTNAME": hostname,
 		"OPENWRT_PASSWORD": acceptancetest.Password,


### PR DESCRIPTION
This helper exists for precisely the reason we need: to perform cleanup
after the tests are finished. Instead of having to thread through the
cleanup everywhere, we do the cleanup once in the
`acceptancetest.StartOpenWrtServer` helper.