### PR TITLE
Add a helper that returns a provider block string

### DIFF
--- a/internal/acceptancetest/helpers.go
+++ b/internal/acceptancetest/helpers.go
@@ -144,6 +144,42 @@ func AuthenticatedClient(
 	return client
 }
 
+// AuthenticatedClientWithProviderBlock starts an OpenWrt server,
+// returns a [*lucirpc.Client] to interact with it,
+// and a stringified provider block.
+func AuthenticatedClientWithProviderBlock(
+	ctx context.Context,
+	dockerPool dockertest.Pool,
+	t *testing.T,
+) (client *lucirpc.Client, providerBlock string) {
+	t.Helper()
+
+	hostname, port := RunOpenWrtServer(ctx, dockerPool, t)
+	client, err := lucirpc.NewClient(
+		ctx,
+		Scheme,
+		hostname,
+		port,
+		Username,
+		Password,
+	)
+	assert.NilError(t, err)
+	providerBlock = fmt.Sprintf(`
+provider "openwrt" {
+	hostname = %q
+	password = %q
+	port = %d
+	username = %q
+}
+`,
+		hostname,
+		Password,
+		port,
+		Username,
+	)
+	return
+}
+
 func checkHealth(
 	ctx context.Context,
 	dockerPool dockertest.Pool,
@@ -191,6 +227,33 @@ func RunOpenWrtServer(
 	port = uint16(intPort)
 
 	return
+}
+
+// RunOpenWrtServerWithProviderBlock constructs a running OpenWrt server,
+// and a stringified provider block.
+func RunOpenWrtServerWithProviderBlock(
+	ctx context.Context,
+	dockerPool dockertest.Pool,
+	t *testing.T,
+) string {
+	t.Helper()
+
+	hostname, port := RunOpenWrtServer(ctx, dockerPool, t)
+	providerBlock := fmt.Sprintf(`
+provider "openwrt" {
+	hostname = %q
+	password = %q
+	port = %d
+	username = %q
+}
+`,
+		hostname,
+		Password,
+		port,
+		Username,
+	)
+
+	return providerBlock
 }
 
 func loadImageCache(

--- a/openwrt/internal/network/device_resource_acceptance_test.go
+++ b/openwrt/internal/network/device_resource_acceptance_test.go
@@ -19,7 +19,7 @@ func TestNetworkDeviceResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	hostname, port := acceptancetest.RunOpenWrtServer(
+	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
 		ctx,
 		*dockerPool,
 		t,
@@ -27,12 +27,7 @@ func TestNetworkDeviceResourceAcceptance(t *testing.T) {
 
 	createAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`
-provider "openwrt" {
-	hostname = %q
-	password = %q
-	port = %d
-	username = %q
-}
+%s
 
 resource "openwrt_network_device" "br_testing" {
 	id = "br_testing"
@@ -44,10 +39,7 @@ resource "openwrt_network_device" "br_testing" {
 	type = "bridge"
 }
 `,
-			hostname,
-			acceptancetest.Password,
-			port,
-			acceptancetest.Username,
+			providerBlock,
 		),
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("openwrt_network_device.br_testing", "id", "br_testing"),
@@ -66,12 +58,7 @@ resource "openwrt_network_device" "br_testing" {
 	}
 	updateAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`
-provider "openwrt" {
-	hostname = %q
-	password = %q
-	port = %d
-	username = %q
-}
+%s
 
 resource "openwrt_network_device" "br_testing" {
 	id = "br_testing"
@@ -87,10 +74,7 @@ resource "openwrt_network_device" "br_testing" {
 	type = "bridge"
 }
 `,
-			hostname,
-			acceptancetest.Password,
-			port,
-			acceptancetest.Username,
+			providerBlock,
 		),
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("openwrt_network_device.br_testing", "id", "br_testing"),

--- a/openwrt/internal/network/globals_data_source_acceptance_test.go
+++ b/openwrt/internal/network/globals_data_source_acceptance_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
-	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt"
 	"gotest.tools/v3/assert"
 )
@@ -22,13 +21,11 @@ func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	hostname, port := acceptancetest.RunOpenWrtServer(
+	client, providerBlock := acceptancetest.AuthenticatedClientWithProviderBlock(
 		ctx,
 		*dockerPool,
 		t,
 	)
-	client, err := lucirpc.NewClient(ctx, acceptancetest.Scheme, hostname, port, acceptancetest.Username, acceptancetest.Password)
-	assert.NilError(t, err)
 	options := map[string]json.RawMessage{
 		"packet_steering": json.RawMessage("false"),
 		"ula_prefix":      json.RawMessage(`"fd12:3456:789a::/48"`),
@@ -44,21 +41,13 @@ func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-provider "openwrt" {
-	hostname = %q
-	password = %q
-	port = %d
-	username = %q
-}
+%s
 
 data "openwrt_network_globals" "this" {
 	id = "globals"
 }
 `,
-					hostname,
-					acceptancetest.Password,
-					port,
-					acceptancetest.Username,
+					providerBlock,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.openwrt_network_globals.this", "id", "globals"),

--- a/openwrt/internal/network/globals_resource_acceptance_test.go
+++ b/openwrt/internal/network/globals_resource_acceptance_test.go
@@ -19,7 +19,7 @@ func TestNetworkGlobalsResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	hostname, port := acceptancetest.RunOpenWrtServer(
+	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
 		ctx,
 		*dockerPool,
 		t,
@@ -27,21 +27,13 @@ func TestNetworkGlobalsResourceAcceptance(t *testing.T) {
 
 	createAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`
-provider "openwrt" {
-	hostname = %q
-	password = %q
-	port = %d
-	username = %q
-}
+%s
 
 resource "openwrt_network_globals" "this" {
 	id = "globals"
 }
 `,
-			hostname,
-			acceptancetest.Password,
-			port,
-			acceptancetest.Username,
+			providerBlock,
 		),
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("openwrt_network_globals.this", "id", "globals"),
@@ -56,12 +48,7 @@ resource "openwrt_network_globals" "this" {
 	}
 	updateAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`
-provider "openwrt" {
-	hostname = %q
-	password = %q
-	port = %d
-	username = %q
-}
+%s
 
 resource "openwrt_network_globals" "this" {
 	id = "globals"
@@ -69,10 +56,7 @@ resource "openwrt_network_globals" "this" {
 	ula_prefix = "fd12:3456:789a::/48"
 }
 `,
-			hostname,
-			acceptancetest.Password,
-			port,
-			acceptancetest.Username,
+			providerBlock,
 		),
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("openwrt_network_globals.this", "id", "globals"),

--- a/openwrt/internal/system/system_data_source_acceptance_test.go
+++ b/openwrt/internal/system/system_data_source_acceptance_test.go
@@ -19,7 +19,7 @@ func TestSystemSystemDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	hostname, port := acceptancetest.RunOpenWrtServer(
+	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
 		ctx,
 		*dockerPool,
 		t,
@@ -32,21 +32,13 @@ func TestSystemSystemDataSourceAcceptance(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-provider "openwrt" {
-	hostname = %q
-	password = %q
-	port = %d
-	username = %q
-}
+%s
 
 data "openwrt_system_system" "this" {
 	id = "cfg01e48a"
 }
 `,
-					hostname,
-					acceptancetest.Password,
-					port,
-					acceptancetest.Username,
+					providerBlock,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.openwrt_system_system.this", "id", "cfg01e48a"),

--- a/openwrt/internal/system/system_resource_acceptance_test.go
+++ b/openwrt/internal/system/system_resource_acceptance_test.go
@@ -19,7 +19,7 @@ func TestSystemSystemResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	hostname, port := acceptancetest.RunOpenWrtServer(
+	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
 		ctx,
 		*dockerPool,
 		t,
@@ -27,21 +27,13 @@ func TestSystemSystemResourceAcceptance(t *testing.T) {
 
 	createAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`
-provider "openwrt" {
-	hostname = %q
-	password = %q
-	port = %d
-	username = %q
-}
+%s
 
 resource "openwrt_system_system" "this" {
 	id = "cfg01e48a"
 }
 `,
-			hostname,
-			acceptancetest.Password,
-			port,
-			acceptancetest.Username,
+			providerBlock,
 		),
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("openwrt_system_system.this", "id", "cfg01e48a"),
@@ -58,12 +50,7 @@ resource "openwrt_system_system" "this" {
 	}
 	updateAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`
-provider "openwrt" {
-	hostname = %q
-	password = %q
-	port = %d
-	username = %q
-}
+%s
 
 resource "openwrt_system_system" "this" {
 	hostname = "OpenWRT"
@@ -73,10 +60,7 @@ resource "openwrt_system_system" "this" {
 	ttylogin = false
 }
 `,
-			hostname,
-			acceptancetest.Password,
-			port,
-			acceptancetest.Username,
+			providerBlock,
 		),
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("openwrt_system_system.this", "id", "cfg01e48a"),


### PR DESCRIPTION
Most of the time, we don't actually care about the connection
credentials for a provider, we just want one that works. Instead of
putting the onus on the caller to figure this out each time, we give
back a provider block string. This helps with the Resource acceptance
test helper case.

We also make a helper that returns a `lucirpc.Client` along with a
provider block string. This helps with the Data Source acceptance test
case.