### PR TITLE
Re-order `system.system` resource acceptance test

### DIFF
--- a/openwrt/internal/system/system_resource_acceptance_test.go
+++ b/openwrt/internal/system/system_resource_acceptance_test.go
@@ -25,7 +25,23 @@ func TestSystemSystemResourceAcceptance(t *testing.T) {
 		t,
 	)
 
-	createAndReadTestStep := resource.TestStep{
+	importTestStep := resource.TestStep{
+		Config: fmt.Sprintf(`
+%s
+
+resource "openwrt_system_system" "this" {
+	id = "cfg01e48a"
+}
+`,
+			providerBlock,
+		),
+		ImportState:        true,
+		ImportStateId:      "cfg01e48a",
+		ImportStatePersist: true,
+		ResourceName:       "openwrt_system_system.this",
+	}
+
+	readTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`
 %s
 
@@ -43,11 +59,7 @@ resource "openwrt_system_system" "this" {
 			resource.TestCheckResourceAttr("openwrt_system_system.this", "ttylogin", "false"),
 		),
 	}
-	importTestStep := resource.TestStep{
-		ImportState:       true,
-		ImportStateVerify: true,
-		ResourceName:      "openwrt_system_system.this",
-	}
+
 	updateAndReadTestStep := resource.TestStep{
 		Config: fmt.Sprintf(`
 %s
@@ -76,8 +88,8 @@ resource "openwrt_system_system" "this" {
 			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
 		},
 		Steps: []resource.TestStep{
-			createAndReadTestStep,
 			importTestStep,
+			readTestStep,
 			updateAndReadTestStep,
 		},
 	})


### PR DESCRIPTION
Since the `system.system` resource seems to always need to exist in
order for an OpenWrt server to run, and because there can be only one
`system.system`, we shouldn't try to emulate the use case of creating
one (as nobody would create a `system.system`).  Instead, we assume one
is already there. We start by importing it, and going from there.