### PR TITLE
Clean up Terraform acceptance tests

### DIFF
--- a/openwrt/internal/network/device_data_source_acceptance_test.go
+++ b/openwrt/internal/network/device_data_source_acceptance_test.go
@@ -35,29 +35,31 @@ func TestNetworkDeviceDataSourceAcceptance(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, ok)
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
+	readDataSource := resource.TestStep{
+		Config: fmt.Sprintf(`
 %s
 
 data "openwrt_network_device" "this" {
 	id = "br_testing"
 }
 `,
-					providerBlock,
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.openwrt_network_device.this", "id", "br_testing"),
-					resource.TestCheckResourceAttr("data.openwrt_network_device.this", "name", "br-testing"),
-					resource.TestCheckResourceAttr("data.openwrt_network_device.this", "ports.0", "eth0"),
-					resource.TestCheckResourceAttr("data.openwrt_network_device.this", "ports.1", "eth1"),
-					resource.TestCheckResourceAttr("data.openwrt_network_device.this", "type", "bridge"),
-				),
-			},
+			providerBlock,
+		),
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("data.openwrt_network_device.this", "id", "br_testing"),
+			resource.TestCheckResourceAttr("data.openwrt_network_device.this", "name", "br-testing"),
+			resource.TestCheckResourceAttr("data.openwrt_network_device.this", "ports.0", "eth0"),
+			resource.TestCheckResourceAttr("data.openwrt_network_device.this", "ports.1", "eth1"),
+			resource.TestCheckResourceAttr("data.openwrt_network_device.this", "type", "bridge"),
+		),
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
+		},
+		Steps: []resource.TestStep{
+			readDataSource,
 		},
 	})
 }

--- a/openwrt/internal/network/device_resource_acceptance_test.go
+++ b/openwrt/internal/network/device_resource_acceptance_test.go
@@ -25,7 +25,7 @@ func TestNetworkDeviceResourceAcceptance(t *testing.T) {
 		t,
 	)
 
-	createAndReadTestStep := resource.TestStep{
+	createAndReadResource := resource.TestStep{
 		Config: fmt.Sprintf(`
 %s
 
@@ -51,12 +51,12 @@ resource "openwrt_network_device" "br_testing" {
 			resource.TestCheckResourceAttr("openwrt_network_device.br_testing", "type", "bridge"),
 		),
 	}
-	importTestStep := resource.TestStep{
+	importValidation := resource.TestStep{
 		ImportState:       true,
 		ImportStateVerify: true,
 		ResourceName:      "openwrt_network_device.br_testing",
 	}
-	updateAndReadTestStep := resource.TestStep{
+	updateAndReadResource := resource.TestStep{
 		Config: fmt.Sprintf(`
 %s
 
@@ -94,9 +94,9 @@ resource "openwrt_network_device" "br_testing" {
 			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
 		},
 		Steps: []resource.TestStep{
-			createAndReadTestStep,
-			importTestStep,
-			updateAndReadTestStep,
+			createAndReadResource,
+			importValidation,
+			updateAndReadResource,
 		},
 	})
 }

--- a/openwrt/internal/network/globals_data_source_acceptance_test.go
+++ b/openwrt/internal/network/globals_data_source_acceptance_test.go
@@ -34,27 +34,29 @@ func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, ok)
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
+	readDataSource := resource.TestStep{
+		Config: fmt.Sprintf(`
 %s
 
 data "openwrt_network_globals" "this" {
 	id = "globals"
 }
 `,
-					providerBlock,
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.openwrt_network_globals.this", "id", "globals"),
-					resource.TestCheckResourceAttr("data.openwrt_network_globals.this", "packet_steering", "false"),
-					resource.TestCheckResourceAttr("data.openwrt_network_globals.this", "ula_prefix", "fd12:3456:789a::/48"),
-				),
-			},
+			providerBlock,
+		),
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("data.openwrt_network_globals.this", "id", "globals"),
+			resource.TestCheckResourceAttr("data.openwrt_network_globals.this", "packet_steering", "false"),
+			resource.TestCheckResourceAttr("data.openwrt_network_globals.this", "ula_prefix", "fd12:3456:789a::/48"),
+		),
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
+		},
+		Steps: []resource.TestStep{
+			readDataSource,
 		},
 	})
 }

--- a/openwrt/internal/network/globals_resource_acceptance_test.go
+++ b/openwrt/internal/network/globals_resource_acceptance_test.go
@@ -25,7 +25,7 @@ func TestNetworkGlobalsResourceAcceptance(t *testing.T) {
 		t,
 	)
 
-	createAndReadTestStep := resource.TestStep{
+	createAndReadResource := resource.TestStep{
 		Config: fmt.Sprintf(`
 %s
 
@@ -41,12 +41,12 @@ resource "openwrt_network_globals" "this" {
 			resource.TestCheckNoResourceAttr("openwrt_network_globals.this", "ula_prefix"),
 		),
 	}
-	importTestStep := resource.TestStep{
+	importValidation := resource.TestStep{
 		ImportState:       true,
 		ImportStateVerify: true,
 		ResourceName:      "openwrt_network_globals.this",
 	}
-	updateAndReadTestStep := resource.TestStep{
+	updateAndReadResource := resource.TestStep{
 		Config: fmt.Sprintf(`
 %s
 
@@ -70,9 +70,9 @@ resource "openwrt_network_globals" "this" {
 			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
 		},
 		Steps: []resource.TestStep{
-			createAndReadTestStep,
-			importTestStep,
-			updateAndReadTestStep,
+			createAndReadResource,
+			importValidation,
+			updateAndReadResource,
 		},
 	})
 }

--- a/openwrt/internal/system/system_data_source_acceptance_test.go
+++ b/openwrt/internal/system/system_data_source_acceptance_test.go
@@ -25,29 +25,31 @@ func TestSystemSystemDataSourceAcceptance(t *testing.T) {
 		t,
 	)
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
+	readDataSource := resource.TestStep{
+		Config: fmt.Sprintf(`
 %s
 
 data "openwrt_system_system" "this" {
 	id = "cfg01e48a"
 }
 `,
-					providerBlock,
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.openwrt_system_system.this", "id", "cfg01e48a"),
-					resource.TestCheckResourceAttr("data.openwrt_system_system.this", "hostname", "OpenWrt"),
-					resource.TestCheckResourceAttr("data.openwrt_system_system.this", "log_size", "64"),
-					resource.TestCheckResourceAttr("data.openwrt_system_system.this", "timezone", "UTC"),
-					resource.TestCheckResourceAttr("data.openwrt_system_system.this", "ttylogin", "false"),
-				),
-			},
+			providerBlock,
+		),
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("data.openwrt_system_system.this", "id", "cfg01e48a"),
+			resource.TestCheckResourceAttr("data.openwrt_system_system.this", "hostname", "OpenWrt"),
+			resource.TestCheckResourceAttr("data.openwrt_system_system.this", "log_size", "64"),
+			resource.TestCheckResourceAttr("data.openwrt_system_system.this", "timezone", "UTC"),
+			resource.TestCheckResourceAttr("data.openwrt_system_system.this", "ttylogin", "false"),
+		),
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
+		},
+		Steps: []resource.TestStep{
+			readDataSource,
 		},
 	})
 }

--- a/openwrt/internal/system/system_resource_acceptance_test.go
+++ b/openwrt/internal/system/system_resource_acceptance_test.go
@@ -25,7 +25,7 @@ func TestSystemSystemResourceAcceptance(t *testing.T) {
 		t,
 	)
 
-	importTestStep := resource.TestStep{
+	importValidation := resource.TestStep{
 		Config: fmt.Sprintf(`
 %s
 
@@ -41,7 +41,7 @@ resource "openwrt_system_system" "this" {
 		ResourceName:       "openwrt_system_system.this",
 	}
 
-	readTestStep := resource.TestStep{
+	readResource := resource.TestStep{
 		Config: fmt.Sprintf(`
 %s
 
@@ -60,7 +60,7 @@ resource "openwrt_system_system" "this" {
 		),
 	}
 
-	updateAndReadTestStep := resource.TestStep{
+	updateAndReadResource := resource.TestStep{
 		Config: fmt.Sprintf(`
 %s
 
@@ -88,9 +88,9 @@ resource "openwrt_system_system" "this" {
 			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
 		},
 		Steps: []resource.TestStep{
-			importTestStep,
-			readTestStep,
-			updateAndReadTestStep,
+			importValidation,
+			readResource,
+			updateAndReadResource,
 		},
 	})
 }


### PR DESCRIPTION
We extract the test cases for Data Sources so it's more consistent. We
also rename these variables so they describe more what their purpose is
rather than their type.