### PR TITLE
Provide a helper for Terraform test steps

### DIFF
--- a/internal/acceptancetest/helpers.go
+++ b/internal/acceptancetest/helpers.go
@@ -13,7 +13,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
+	"github.com/joneshf/terraform-provider-openwrt/openwrt"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 	"gotest.tools/v3/assert"
@@ -234,6 +238,24 @@ func Setup(
 	}
 
 	return
+}
+
+// TerraformSteps removes a bit of boilerplate around setting up the [resource.TestStep]s.
+func TerraformSteps(
+	t *testing.T,
+	testStep resource.TestStep,
+	testSteps ...resource.TestStep,
+) {
+	t.Helper()
+
+	allTestSteps := append([]resource.TestStep{testStep}, testSteps...)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
+		},
+		Steps: allTestSteps,
+	})
+
 }
 
 func checkHealth(

--- a/openwrt/internal/network/device_data_source_acceptance_test.go
+++ b/openwrt/internal/network/device_data_source_acceptance_test.go
@@ -6,14 +6,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
-	"github.com/joneshf/terraform-provider-openwrt/openwrt"
 	"gotest.tools/v3/assert"
 )
 
@@ -54,12 +50,8 @@ data "openwrt_network_device" "this" {
 		),
 	}
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
-		},
-		Steps: []resource.TestStep{
-			readDataSource,
-		},
-	})
+	acceptancetest.TerraformSteps(
+		t,
+		readDataSource,
+	)
 }

--- a/openwrt/internal/network/device_resource_acceptance_test.go
+++ b/openwrt/internal/network/device_resource_acceptance_test.go
@@ -5,14 +5,10 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
-	"github.com/joneshf/terraform-provider-openwrt/openwrt"
 )
 
 func TestNetworkDeviceResourceAcceptance(t *testing.T) {
@@ -89,14 +85,10 @@ resource "openwrt_network_device" "br_testing" {
 		),
 	}
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
-		},
-		Steps: []resource.TestStep{
-			createAndReadResource,
-			importValidation,
-			updateAndReadResource,
-		},
-	})
+	acceptancetest.TerraformSteps(
+		t,
+		createAndReadResource,
+		importValidation,
+		updateAndReadResource,
+	)
 }

--- a/openwrt/internal/network/globals_data_source_acceptance_test.go
+++ b/openwrt/internal/network/globals_data_source_acceptance_test.go
@@ -6,14 +6,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
-	"github.com/joneshf/terraform-provider-openwrt/openwrt"
 	"gotest.tools/v3/assert"
 )
 
@@ -51,12 +47,8 @@ data "openwrt_network_globals" "this" {
 		),
 	}
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
-		},
-		Steps: []resource.TestStep{
-			readDataSource,
-		},
-	})
+	acceptancetest.TerraformSteps(
+		t,
+		readDataSource,
+	)
 }

--- a/openwrt/internal/network/globals_resource_acceptance_test.go
+++ b/openwrt/internal/network/globals_resource_acceptance_test.go
@@ -5,14 +5,10 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
-	"github.com/joneshf/terraform-provider-openwrt/openwrt"
 )
 
 func TestNetworkGlobalsResourceAcceptance(t *testing.T) {
@@ -65,14 +61,10 @@ resource "openwrt_network_globals" "this" {
 		),
 	}
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
-		},
-		Steps: []resource.TestStep{
-			createAndReadResource,
-			importValidation,
-			updateAndReadResource,
-		},
-	})
+	acceptancetest.TerraformSteps(
+		t,
+		createAndReadResource,
+		importValidation,
+		updateAndReadResource,
+	)
 }

--- a/openwrt/internal/system/system_data_source_acceptance_test.go
+++ b/openwrt/internal/system/system_data_source_acceptance_test.go
@@ -5,14 +5,10 @@ package system_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
-	"github.com/joneshf/terraform-provider-openwrt/openwrt"
 )
 
 func TestSystemSystemDataSourceAcceptance(t *testing.T) {
@@ -44,12 +40,8 @@ data "openwrt_system_system" "this" {
 		),
 	}
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
-		},
-		Steps: []resource.TestStep{
-			readDataSource,
-		},
-	})
+	acceptancetest.TerraformSteps(
+		t,
+		readDataSource,
+	)
 }

--- a/openwrt/internal/system/system_resource_acceptance_test.go
+++ b/openwrt/internal/system/system_resource_acceptance_test.go
@@ -5,14 +5,10 @@ package system_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
-	"github.com/joneshf/terraform-provider-openwrt/openwrt"
 )
 
 func TestSystemSystemResourceAcceptance(t *testing.T) {
@@ -83,14 +79,10 @@ resource "openwrt_system_system" "this" {
 		),
 	}
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"openwrt": providerserver.NewProtocol6WithError(openwrt.New("test", os.LookupEnv)),
-		},
-		Steps: []resource.TestStep{
-			importValidation,
-			readResource,
-			updateAndReadResource,
-		},
-	})
+	acceptancetest.TerraformSteps(
+		t,
+		importValidation,
+		readResource,
+		updateAndReadResource,
+	)
 }


### PR DESCRIPTION
We're doing roughly the same thing everywhere. We also have to make sure
we get the provider setup right, as otherwise it'll make the test fail.
In order to make things a bit easier, we provide a helper that bundles
up a bunch of that logic.