### PR TITLE
Remove superfluous `*testing.M` argument

### DIFF
--- a/internal/acceptancetest/helpers.go
+++ b/internal/acceptancetest/helpers.go
@@ -162,7 +162,6 @@ provider "openwrt" {
 // The tearDown function must be called after tests are finished.
 func Setup(
 	ctx context.Context,
-	m *testing.M,
 ) (tearDown func(), dockerPool *dockertest.Pool, err error) {
 	var conn net.Conn
 	tearDown = func() {

--- a/lucirpc/client_acceptance_test.go
+++ b/lucirpc/client_acceptance_test.go
@@ -342,7 +342,7 @@ func TestMain(m *testing.M) {
 		tearDown func()
 	)
 	ctx := context.Background()
-	tearDown, dockerPool, err = acceptancetest.Setup(ctx, m)
+	tearDown, dockerPool, err = acceptancetest.Setup(ctx)
 	defer func() {
 		tearDown()
 		os.Exit(code)

--- a/openwrt/internal/network/acceptance_test.go
+++ b/openwrt/internal/network/acceptance_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 		tearDown func()
 	)
 	ctx := context.Background()
-	tearDown, dockerPool, err = acceptancetest.Setup(ctx, m)
+	tearDown, dockerPool, err = acceptancetest.Setup(ctx)
 	defer func() {
 		tearDown()
 		os.Exit(code)

--- a/openwrt/internal/system/acceptance_test.go
+++ b/openwrt/internal/system/acceptance_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 		tearDown func()
 	)
 	ctx := context.Background()
-	tearDown, dockerPool, err = acceptancetest.Setup(ctx, m)
+	tearDown, dockerPool, err = acceptancetest.Setup(ctx)
 	defer func() {
 		tearDown()
 		os.Exit(code)

--- a/openwrt/provider_acceptance_test.go
+++ b/openwrt/provider_acceptance_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		tearDown func()
 	)
 	ctx := context.Background()
-	tearDown, dockerPool, err = acceptancetest.Setup(ctx, m)
+	tearDown, dockerPool, err = acceptancetest.Setup(ctx)
 	defer func() {
 		tearDown()
 		os.Exit(code)


### PR DESCRIPTION
We don't use this argument, so we can remove it.