### PR TITLE
Set full type name in `Configure` methods

### DIFF
--- a/openwrt/internal/lucirpcglue/provider_data.go
+++ b/openwrt/internal/lucirpcglue/provider_data.go
@@ -11,9 +11,11 @@ type ConfigureRequest struct {
 
 func NewProviderData(
 	client lucirpc.Client,
+	typeName string,
 ) ProviderData {
 	return ProviderData{
-		Client: client,
+		Client:   client,
+		TypeName: typeName,
 	}
 }
 
@@ -36,5 +38,6 @@ func ParseProviderData(
 }
 
 type ProviderData struct {
-	Client lucirpc.Client
+	Client   lucirpc.Client
+	TypeName string
 }

--- a/openwrt/provider.go
+++ b/openwrt/provider.go
@@ -380,7 +380,7 @@ func setProviderData(
 ) {
 	tflog.Debug(ctx, "Making OpenWrt provider data available during DataSource, and Resource type Configure methods")
 
-	providerData := lucirpcglue.NewProviderData(*client)
+	providerData := lucirpcglue.NewProviderData(*client, providerTypeName)
 	res.DataSourceData = providerData
 	res.ResourceData = providerData
 }


### PR DESCRIPTION
As mentioned in a previous change, the thing creating the Data Source or
Resource it calls the `Metadata` method on doesn't actually hold onto
the Data Source or Resource it just created. So, we can't set any data
in that method and expect it to persist.

What we do instead, is set the data in the `Configure` method. This
seems to persist for the lifecycle of the Data Source or Resource. Then,
our logs work the way they're supposed to.

We also move the setting of the `terraformType` to the initialization of
the respective Data Source or Resource function. It doesn't really make
a whole lot of sense to wait to set that in the `Configure` method,
since we already know at compile time what it's going to be.