### PR TITLE
Track the `nixos-22.11` branch in the flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676718858,
-        "narHash": "sha256-giQecvcifVLNHCC9lMfTGP09tNxXhOMw+d/aql7MhRw=",
+        "lastModified": 1678972866,
+        "narHash": "sha256-YV8BcNWfNVgS449B6hFYFUg4kwVIQMNehZP+FNDs1LY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6d5772f3515b8518d50122471381feae7cbae36",
+        "rev": "cd34d6ed7ba7d5c4e44b04a53dc97edb52f2766c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
-        "rev": "e6d5772f3515b8518d50122471381feae7cbae36",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,8 @@
   inputs = {
     nixpkgs = {
       owner = "NixOS";
+      ref = "nixos-22.11";
       repo = "nixpkgs";
-      # 22.11
-      rev = "e6d5772f3515b8518d50122471381feae7cbae36";
       type = "github";
     };
   };


### PR DESCRIPTION
To try and keep things up to date easier, we're going to switch to using
a reference rather than a revision. It *seems* like a reference can be
updated more easily, but it's not actually clear how this will work out
in practice. And the `nix` docs don't really explain it too well:
https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake#flake-references.
The explanation on Zero to Nix seems to imply that it works the way
we're thinking, though:
https://zero-to-nix.com/concepts/flakes#lockfile.

As usually, we should be able to back out of this change if it proves to
be a bad decision.