### PR TITLE
Name the LuCI JSON-RPC options

### DIFF
--- a/lucirpc/client.go
+++ b/lucirpc/client.go
@@ -438,6 +438,8 @@ func NewClient(
 	return client, nil
 }
 
+// Options are the actual UCI options for each section.
+// The values can be booleans, integers, lists, and strings.
 type Options map[string]json.RawMessage
 
 type jsonRPCClient struct {

--- a/lucirpc/client.go
+++ b/lucirpc/client.go
@@ -80,7 +80,7 @@ func (c *Client) CreateSection(
 	config string,
 	sectionType string,
 	section string,
-	options map[string]json.RawMessage,
+	options Options,
 ) (bool, error) {
 	marshalledConfig, err := json.Marshal(config)
 	if err != nil {
@@ -209,7 +209,7 @@ func (c *Client) GetSection(
 	ctx context.Context,
 	config string,
 	section string,
-) (map[string]json.RawMessage, error) {
+) (Options, error) {
 	marshalledConfig, err := json.Marshal(config)
 	if err != nil {
 		return nil, fmt.Errorf("unable to serialize config %q for %s: %w", config, humanReadableGetSection, err)
@@ -254,7 +254,7 @@ func (c *Client) GetSection(
 		return nil, fmt.Errorf("incorrect config (%q) and/or section (%q): result from LuCI: %s", config, section, *responseBody)
 	}
 
-	var result map[string]json.RawMessage
+	var result Options
 	err = json.Unmarshal(*responseBody, &result)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse %s response: %w", humanReadableGetSection, err)
@@ -304,7 +304,7 @@ func (c *Client) UpdateSection(
 	ctx context.Context,
 	config string,
 	section string,
-	options map[string]json.RawMessage,
+	options Options,
 ) (bool, error) {
 	marshalledConfig, err := json.Marshal(config)
 	if err != nil {
@@ -437,6 +437,8 @@ func NewClient(
 	}
 	return client, nil
 }
+
+type Options map[string]json.RawMessage
 
 type jsonRPCClient struct {
 	address url.URL

--- a/lucirpc/client_acceptance_test.go
+++ b/lucirpc/client_acceptance_test.go
@@ -40,7 +40,7 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 			"",
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -65,7 +65,7 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 			"network",
 			"interface",
 			"testing",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -90,7 +90,7 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 			"network",
 			"interface",
 			"testing",
-			map[string]json.RawMessage{
+			lucirpc.Options{
 				"option_1": json.RawMessage("true"),
 				"option_2": json.RawMessage("31"),
 				"option_3": json.RawMessage(`["foo", "bar", "baz"]`),
@@ -105,7 +105,7 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 			"testing",
 		)
 		assert.NilError(t, err)
-		assert.DeepEqual(t, got, map[string]json.RawMessage{
+		assert.DeepEqual(t, got, lucirpc.Options{
 			".anonymous": json.RawMessage("false"),
 			".name":      json.RawMessage(`"testing"`),
 			".type":      json.RawMessage(`"interface"`),
@@ -132,7 +132,7 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 			"network",
 			"interface",
 			"testing",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -187,7 +187,7 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 			"network",
 			"interface",
 			"testing",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 		assert.NilError(t, err)
 
@@ -218,7 +218,7 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 			"network",
 			"interface",
 			"testing",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 		assert.NilError(t, err)
 
@@ -254,7 +254,7 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 			"network",
 			"interface",
 			"testing",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 		assert.NilError(t, err)
 
@@ -321,7 +321,7 @@ func TestClientGetSectionAcceptance(t *testing.T) {
 
 		// Then
 		assert.NilError(t, err)
-		want := map[string]json.RawMessage{
+		want := lucirpc.Options{
 			".anonymous":   json.RawMessage("true"),
 			".name":        json.RawMessage(`"cfg01e48a"`),
 			".type":        json.RawMessage(`"system"`),
@@ -401,7 +401,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			ctx,
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -424,7 +424,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			"network",
 			"interface",
 			"testing",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 		assert.NilError(t, err)
 
@@ -433,7 +433,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			ctx,
 			"network",
 			"testing",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -456,7 +456,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			"network",
 			"interface",
 			"testing",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 		assert.NilError(t, err)
 
@@ -465,7 +465,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			ctx,
 			"network",
 			"testing",
-			map[string]json.RawMessage{
+			lucirpc.Options{
 				"foo": json.RawMessage("true"),
 			},
 		)
@@ -490,7 +490,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			"network",
 			"interface",
 			"testing",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 		assert.NilError(t, err)
 
@@ -499,7 +499,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			ctx,
 			"network",
 			"testing",
-			map[string]json.RawMessage{
+			lucirpc.Options{
 				"option_1": json.RawMessage("true"),
 				"option_2": json.RawMessage("31"),
 				"option_3": json.RawMessage(`["foo", "bar", "baz"]`),
@@ -514,7 +514,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			"testing",
 		)
 		assert.NilError(t, err)
-		assert.DeepEqual(t, got, map[string]json.RawMessage{
+		assert.DeepEqual(t, got, lucirpc.Options{
 			".anonymous": json.RawMessage("false"),
 			".name":      json.RawMessage(`"testing"`),
 			".type":      json.RawMessage(`"interface"`),
@@ -539,7 +539,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			"network",
 			"interface",
 			"testing",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 		assert.NilError(t, err)
 
@@ -548,7 +548,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			ctx,
 			"network",
 			"testing",
-			map[string]json.RawMessage{
+			lucirpc.Options{
 				"option_1": json.RawMessage("true"),
 				"option_2": json.RawMessage("31"),
 				"option_3": json.RawMessage(`["foo", "bar", "baz"]`),

--- a/lucirpc/client_test.go
+++ b/lucirpc/client_test.go
@@ -33,7 +33,7 @@ func TestClientCreateSection(t *testing.T) {
 			"",
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -67,7 +67,7 @@ func TestClientCreateSection(t *testing.T) {
 			"",
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -93,7 +93,7 @@ func TestClientCreateSection(t *testing.T) {
 			"",
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -119,7 +119,7 @@ func TestClientCreateSection(t *testing.T) {
 			"",
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -147,7 +147,7 @@ func TestClientCreateSection(t *testing.T) {
 			"",
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -175,7 +175,7 @@ func TestClientCreateSection(t *testing.T) {
 			"",
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -203,7 +203,7 @@ func TestClientCreateSection(t *testing.T) {
 			"",
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -220,7 +220,7 @@ func TestClientCreateSection(t *testing.T) {
 			switch r.URL.Path {
 			case "/cgi-bin/luci/rpc/uci":
 				decoder := json.NewDecoder(r.Body)
-				var body map[string]json.RawMessage
+				var body lucirpc.Options
 				err := decoder.Decode(&body)
 				assert.NilError(t, err)
 				method, ok := body["method"]
@@ -251,7 +251,7 @@ func TestClientCreateSection(t *testing.T) {
 			"",
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -451,7 +451,7 @@ func TestClientDeleteSection(t *testing.T) {
 			switch r.URL.Path {
 			case "/cgi-bin/luci/rpc/uci":
 				decoder := json.NewDecoder(r.Body)
-				var body map[string]json.RawMessage
+				var body lucirpc.Options
 				err := decoder.Decode(&body)
 				assert.NilError(t, err)
 				method, ok := body["method"]
@@ -725,7 +725,7 @@ func TestClientGetSection(t *testing.T) {
 
 		// Then
 		assert.NilError(t, err)
-		want := map[string]json.RawMessage{
+		want := lucirpc.Options{
 			".name": json.RawMessage(`"section-name"`),
 			"baz":   json.RawMessage(`"1"`),
 			"foo":   json.RawMessage(`"bar"`),
@@ -922,7 +922,7 @@ func TestClientUpdateSection(t *testing.T) {
 			ctx,
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -955,7 +955,7 @@ func TestClientUpdateSection(t *testing.T) {
 			ctx,
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -980,7 +980,7 @@ func TestClientUpdateSection(t *testing.T) {
 			ctx,
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -1005,7 +1005,7 @@ func TestClientUpdateSection(t *testing.T) {
 			ctx,
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -1032,7 +1032,7 @@ func TestClientUpdateSection(t *testing.T) {
 			ctx,
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -1059,7 +1059,7 @@ func TestClientUpdateSection(t *testing.T) {
 			ctx,
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -1086,7 +1086,7 @@ func TestClientUpdateSection(t *testing.T) {
 			ctx,
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then
@@ -1103,7 +1103,7 @@ func TestClientUpdateSection(t *testing.T) {
 			switch r.URL.Path {
 			case "/cgi-bin/luci/rpc/uci":
 				decoder := json.NewDecoder(r.Body)
-				var body map[string]json.RawMessage
+				var body lucirpc.Options
 				err := decoder.Decode(&body)
 				assert.NilError(t, err)
 				method, ok := body["method"]
@@ -1133,7 +1133,7 @@ func TestClientUpdateSection(t *testing.T) {
 			ctx,
 			"",
 			"",
-			map[string]json.RawMessage{},
+			lucirpc.Options{},
 		)
 
 		// Then

--- a/openwrt/internal/lucirpcglue/attribute.go
+++ b/openwrt/internal/lucirpcglue/attribute.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
 )
 
@@ -118,15 +119,15 @@ func (a BoolSchemaAttribute[Model, Request, Response]) Upsert(
 func IdSchemaAttribute[Model any](
 	get func(Model) types.String,
 	set func(*Model, types.String),
-) SchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage] {
-	return StringSchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage]{
+) SchemaAttribute[Model, lucirpc.Options, lucirpc.Options] {
+	return StringSchemaAttribute[Model, lucirpc.Options, lucirpc.Options]{
 		DataSourceExistence: Required,
 		Description:         idAttributeDescription,
 		ReadResponse: func(
 			ctx context.Context,
 			fullTypeName string,
 			terraformType string,
-			section map[string]json.RawMessage,
+			section lucirpc.Options,
 			model Model,
 		) (context.Context, Model, diag.Diagnostics) {
 			ctx, value, diagnostics := GetMetadataString(ctx, fullTypeName, terraformType, section, idUCISection)
@@ -137,9 +138,9 @@ func IdSchemaAttribute[Model any](
 		UpsertRequest: func(
 			ctx context.Context,
 			fullTypeName string,
-			options map[string]json.RawMessage,
+			options lucirpc.Options,
 			model Model,
-		) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+		) (context.Context, lucirpc.Options, diag.Diagnostics) {
 			id := get(model)
 			ctx = logger.SetFieldString(ctx, fullTypeName, ResourceTerraformType, IdAttribute, id)
 			return ctx, options, diag.Diagnostics{}
@@ -216,12 +217,12 @@ func ReadResponseOptionBool[Model any](
 	set func(*Model, types.Bool),
 	attribute string,
 	option string,
-) func(context.Context, string, string, map[string]json.RawMessage, Model) (context.Context, Model, diag.Diagnostics) {
+) func(context.Context, string, string, lucirpc.Options, Model) (context.Context, Model, diag.Diagnostics) {
 	return func(
 		ctx context.Context,
 		fullTypeName string,
 		terraformType string,
-		section map[string]json.RawMessage,
+		section lucirpc.Options,
 		model Model,
 	) (context.Context, Model, diag.Diagnostics) {
 		ctx, value, diagnostics := GetOptionBool(ctx, fullTypeName, terraformType, section, path.Root(attribute), option)
@@ -234,12 +235,12 @@ func ReadResponseOptionInt64[Model any](
 	set func(*Model, types.Int64),
 	attribute string,
 	option string,
-) func(context.Context, string, string, map[string]json.RawMessage, Model) (context.Context, Model, diag.Diagnostics) {
+) func(context.Context, string, string, lucirpc.Options, Model) (context.Context, Model, diag.Diagnostics) {
 	return func(
 		ctx context.Context,
 		fullTypeName string,
 		terraformType string,
-		section map[string]json.RawMessage,
+		section lucirpc.Options,
 		model Model,
 	) (context.Context, Model, diag.Diagnostics) {
 		ctx, value, diagnostics := GetOptionInt64(ctx, fullTypeName, terraformType, section, path.Root(attribute), option)
@@ -252,12 +253,12 @@ func ReadResponseOptionSetString[Model any](
 	set func(*Model, types.Set),
 	attribute string,
 	option string,
-) func(context.Context, string, string, map[string]json.RawMessage, Model) (context.Context, Model, diag.Diagnostics) {
+) func(context.Context, string, string, lucirpc.Options, Model) (context.Context, Model, diag.Diagnostics) {
 	return func(
 		ctx context.Context,
 		fullTypeName string,
 		terraformType string,
-		section map[string]json.RawMessage,
+		section lucirpc.Options,
 		model Model,
 	) (context.Context, Model, diag.Diagnostics) {
 		ctx, value, diagnostics := GetOptionSetString(ctx, fullTypeName, terraformType, section, path.Root(attribute), option)
@@ -270,12 +271,12 @@ func ReadResponseOptionString[Model any](
 	set func(*Model, types.String),
 	attribute string,
 	option string,
-) func(context.Context, string, string, map[string]json.RawMessage, Model) (context.Context, Model, diag.Diagnostics) {
+) func(context.Context, string, string, lucirpc.Options, Model) (context.Context, Model, diag.Diagnostics) {
 	return func(
 		ctx context.Context,
 		fullTypeName string,
 		terraformType string,
-		section map[string]json.RawMessage,
+		section lucirpc.Options,
 		model Model,
 	) (context.Context, Model, diag.Diagnostics) {
 		ctx, value, diagnostics := GetOptionString(ctx, fullTypeName, terraformType, section, path.Root(attribute), option)
@@ -448,13 +449,13 @@ func UpsertRequestOptionBool[Model any](
 	get func(Model) types.Bool,
 	attribute string,
 	option string,
-) func(context.Context, string, map[string]json.RawMessage, Model) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+) func(context.Context, string, lucirpc.Options, Model) (context.Context, lucirpc.Options, diag.Diagnostics) {
 	return func(
 		ctx context.Context,
 		fullTypeName string,
-		options map[string]json.RawMessage,
+		options lucirpc.Options,
 		model Model,
-	) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+	) (context.Context, lucirpc.Options, diag.Diagnostics) {
 		str := get(model)
 		if !hasValue(str) {
 			return ctx, options, diag.Diagnostics{}
@@ -475,13 +476,13 @@ func UpsertRequestOptionInt64[Model any](
 	get func(Model) types.Int64,
 	attribute string,
 	option string,
-) func(context.Context, string, map[string]json.RawMessage, Model) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+) func(context.Context, string, lucirpc.Options, Model) (context.Context, lucirpc.Options, diag.Diagnostics) {
 	return func(
 		ctx context.Context,
 		fullTypeName string,
-		options map[string]json.RawMessage,
+		options lucirpc.Options,
 		model Model,
-	) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+	) (context.Context, lucirpc.Options, diag.Diagnostics) {
 		str := get(model)
 		if !hasValue(str) {
 			return ctx, options, diag.Diagnostics{}
@@ -502,13 +503,13 @@ func UpsertRequestOptionSetString[Model any](
 	get func(Model) types.Set,
 	attribute string,
 	option string,
-) func(context.Context, string, map[string]json.RawMessage, Model) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+) func(context.Context, string, lucirpc.Options, Model) (context.Context, lucirpc.Options, diag.Diagnostics) {
 	return func(
 		ctx context.Context,
 		fullTypeName string,
-		options map[string]json.RawMessage,
+		options lucirpc.Options,
 		model Model,
-	) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+	) (context.Context, lucirpc.Options, diag.Diagnostics) {
 		str := get(model)
 		if !hasValue(str) {
 			return ctx, options, diag.Diagnostics{}
@@ -529,13 +530,13 @@ func UpsertRequestOptionString[Model any](
 	get func(Model) types.String,
 	attribute string,
 	option string,
-) func(context.Context, string, map[string]json.RawMessage, Model) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+) func(context.Context, string, lucirpc.Options, Model) (context.Context, lucirpc.Options, diag.Diagnostics) {
 	return func(
 		ctx context.Context,
 		fullTypeName string,
-		options map[string]json.RawMessage,
+		options lucirpc.Options,
 		model Model,
-	) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+	) (context.Context, lucirpc.Options, diag.Diagnostics) {
 		str := get(model)
 		if !hasValue(str) {
 			return ctx, options, diag.Diagnostics{}

--- a/openwrt/internal/lucirpcglue/data_source.go
+++ b/openwrt/internal/lucirpcglue/data_source.go
@@ -2,7 +2,6 @@ package lucirpcglue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -19,7 +18,7 @@ var (
 
 func NewDataSource[Model any](
 	getId func(Model) types.String,
-	schemaAttributes map[string]SchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage],
+	schemaAttributes map[string]SchemaAttribute[Model, lucirpc.Options, lucirpc.Options],
 	schemaDescription string,
 	uciConfig string,
 	uciType string,
@@ -38,7 +37,7 @@ type dataSource[Model any] struct {
 	client            lucirpc.Client
 	fullTypeName      string
 	getId             func(Model) types.String
-	schemaAttributes  map[string]SchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage]
+	schemaAttributes  map[string]SchemaAttribute[Model, lucirpc.Options, lucirpc.Options]
 	schemaDescription string
 	terraformType     string
 	uciConfig         string

--- a/openwrt/internal/lucirpcglue/metadata.go
+++ b/openwrt/internal/lucirpcglue/metadata.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
 )
 
@@ -16,7 +17,7 @@ func GetMetadataString(
 	ctx context.Context,
 	fullTypeName string,
 	terraformType string,
-	section map[string]json.RawMessage,
+	section lucirpc.Options,
 	key string,
 ) (context.Context, types.String, diag.Diagnostics) {
 	diagnostics := diag.Diagnostics{}

--- a/openwrt/internal/lucirpcglue/model.go
+++ b/openwrt/internal/lucirpcglue/model.go
@@ -2,7 +2,6 @@ package lucirpcglue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -14,12 +13,12 @@ func GenerateUpsertBody[Model any](
 	ctx context.Context,
 	fullTypeName string,
 	model Model,
-	attributes map[string]SchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage],
-) (context.Context, map[string]json.RawMessage, diag.Diagnostics) {
+	attributes map[string]SchemaAttribute[Model, lucirpc.Options, lucirpc.Options],
+) (context.Context, lucirpc.Options, diag.Diagnostics) {
 	tflog.Info(ctx, "Generating API request body")
 	var diagnostics diag.Diagnostics
 	allDiagnostics := diag.Diagnostics{}
-	options := map[string]json.RawMessage{}
+	options := lucirpc.Options{}
 
 	tflog.Debug(ctx, "Handling attributes")
 	for _, attribute := range attributes {
@@ -35,7 +34,7 @@ func ReadModel[Model any](
 	fullTypeName string,
 	terraformType string,
 	client lucirpc.Client,
-	attributes map[string]SchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage],
+	attributes map[string]SchemaAttribute[Model, lucirpc.Options, lucirpc.Options],
 	uciConfig string,
 	uciSection string,
 ) (context.Context, Model, diag.Diagnostics) {

--- a/openwrt/internal/lucirpcglue/option.go
+++ b/openwrt/internal/lucirpcglue/option.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/logger"
 )
 
@@ -20,7 +21,7 @@ func GetOptionBool(
 	ctx context.Context,
 	fullTypeName string,
 	terraformType string,
-	section map[string]json.RawMessage,
+	section lucirpc.Options,
 	attribute path.Path,
 	option string,
 ) (context.Context, types.Bool, diag.Diagnostics) {
@@ -72,7 +73,7 @@ func GetOptionInt64(
 	ctx context.Context,
 	fullTypeName string,
 	terraformType string,
-	section map[string]json.RawMessage,
+	section lucirpc.Options,
 	attribute path.Path,
 	option string,
 ) (context.Context, types.Int64, diag.Diagnostics) {
@@ -117,7 +118,7 @@ func GetOptionSetString(
 	ctx context.Context,
 	fullTypeName string,
 	terraformType string,
-	section map[string]json.RawMessage,
+	section lucirpc.Options,
 	attribute path.Path,
 	option string,
 ) (context.Context, types.Set, diag.Diagnostics) {
@@ -172,7 +173,7 @@ func GetOptionString(
 	ctx context.Context,
 	fullTypeName string,
 	terraformType string,
-	section map[string]json.RawMessage,
+	section lucirpc.Options,
 	attribute path.Path,
 	option string,
 ) (context.Context, types.String, diag.Diagnostics) {

--- a/openwrt/internal/lucirpcglue/resource.go
+++ b/openwrt/internal/lucirpcglue/resource.go
@@ -2,7 +2,6 @@ package lucirpcglue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -22,7 +21,7 @@ var (
 
 func NewResource[Model any](
 	getId func(Model) types.String,
-	schemaAttributes map[string]SchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage],
+	schemaAttributes map[string]SchemaAttribute[Model, lucirpc.Options, lucirpc.Options],
 	schemaDescription string,
 	uciConfig string,
 	uciType string,
@@ -41,7 +40,7 @@ type deviceResource[Model any] struct {
 	client            lucirpc.Client
 	fullTypeName      string
 	getId             func(Model) types.String
-	schemaAttributes  map[string]SchemaAttribute[Model, map[string]json.RawMessage, map[string]json.RawMessage]
+	schemaAttributes  map[string]SchemaAttribute[Model, lucirpc.Options, lucirpc.Options]
 	schemaDescription string
 	terraformType     string
 	uciConfig         string

--- a/openwrt/internal/lucirpcglue/section.go
+++ b/openwrt/internal/lucirpcglue/section.go
@@ -2,7 +2,6 @@ package lucirpcglue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -17,7 +16,7 @@ func CreateSection(
 	config string,
 	sectionType string,
 	section string,
-	options map[string]json.RawMessage,
+	options lucirpc.Options,
 ) diag.Diagnostics {
 	diagnostics := diag.Diagnostics{}
 	result, err := client.CreateSection(
@@ -86,7 +85,7 @@ func GetSection(
 	client lucirpc.Client,
 	config string,
 	section string,
-) (map[string]json.RawMessage, diag.Diagnostics) {
+) (lucirpc.Options, diag.Diagnostics) {
 	diagnostics := diag.Diagnostics{}
 	result, err := client.GetSection(ctx, config, section)
 	if err != nil {
@@ -94,7 +93,7 @@ func GetSection(
 			fmt.Sprintf("problem getting %s.%s section", config, section),
 			err.Error(),
 		)
-		return map[string]json.RawMessage{}, diagnostics
+		return lucirpc.Options{}, diagnostics
 	}
 
 	return result, diagnostics
@@ -107,7 +106,7 @@ func UpdateSection(
 	client lucirpc.Client,
 	config string,
 	section string,
-	options map[string]json.RawMessage,
+	options lucirpc.Options,
 ) diag.Diagnostics {
 	diagnostics := diag.Diagnostics{}
 	result, err := client.UpdateSection(

--- a/openwrt/internal/network/device.go
+++ b/openwrt/internal/network/device.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"encoding/json"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -12,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
@@ -64,7 +64,7 @@ const (
 )
 
 var (
-	deviceBridgePortsSchemaAttribute = lucirpcglue.SetStringSchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceBridgePortsSchemaAttribute = lucirpcglue.SetStringSchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		Description:       deviceBridgePortsAttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionSetString(deviceModelSetBridgePorts, deviceBridgePortsAttribute, deviceBridgePortsUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
@@ -78,7 +78,7 @@ var (
 		},
 	}
 
-	deviceBringUpEmptyBridgeSchemaAttribute = lucirpcglue.BoolSchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceBringUpEmptyBridgeSchemaAttribute = lucirpcglue.BoolSchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		Description:       deviceBringUpEmptyBridgeAttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionBool(deviceModelSetBringUpEmptyBridge, deviceBringUpEmptyBridgeAttribute, deviceBringUpEmptyBridgeUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
@@ -91,7 +91,7 @@ var (
 		},
 	}
 
-	deviceDADTransmitsSchemaAttribute = lucirpcglue.Int64SchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceDADTransmitsSchemaAttribute = lucirpcglue.Int64SchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		Description:       deviceDADTransmitsAttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(deviceModelSetDADTransmits, deviceDADTransmitsAttribute, deviceDADTransmitsUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
@@ -105,14 +105,14 @@ var (
 		},
 	}
 
-	deviceEnableIPv6SchemaAttribute = lucirpcglue.BoolSchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceEnableIPv6SchemaAttribute = lucirpcglue.BoolSchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		Description:       deviceEnableIPv6AttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionBool(deviceModelSetEnableIPv6, deviceEnableIPv6Attribute, deviceEnableIPv6UCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionBool(deviceModelGetEnableIPv6, deviceEnableIPv6Attribute, deviceEnableIPv6UCIOption),
 	}
 
-	deviceMacAddressSchemaAttribute = lucirpcglue.StringSchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceMacAddressSchemaAttribute = lucirpcglue.StringSchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		Description:       deviceMacAddressAttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(deviceModelSetMacAddress, deviceMacAddressAttribute, deviceMacAddressUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
@@ -125,7 +125,7 @@ var (
 		},
 	}
 
-	deviceMTUSchemaAttribute = lucirpcglue.Int64SchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceMTUSchemaAttribute = lucirpcglue.Int64SchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		Description:       deviceMTUAttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(deviceModelSetMTU, deviceMTUAttribute, deviceMTUUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
@@ -135,7 +135,7 @@ var (
 		},
 	}
 
-	deviceMTU6SchemaAttribute = lucirpcglue.Int64SchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceMTU6SchemaAttribute = lucirpcglue.Int64SchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		Description:       deviceMTU6AttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(deviceModelSetMTU6, deviceMTU6Attribute, deviceMTU6UCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
@@ -149,14 +149,14 @@ var (
 		},
 	}
 
-	deviceNameSchemaAttribute = lucirpcglue.StringSchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceNameSchemaAttribute = lucirpcglue.StringSchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		Description:       deviceNameAttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(deviceModelSetName, deviceNameAttribute, deviceNameUCIOption),
 		ResourceExistence: lucirpcglue.Required,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(deviceModelGetName, deviceNameAttribute, deviceNameUCIOption),
 	}
 
-	deviceSchemaAttributes = map[string]lucirpcglue.SchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceSchemaAttributes = map[string]lucirpcglue.SchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		deviceBridgePortsAttribute:        deviceBridgePortsSchemaAttribute,
 		deviceBringUpEmptyBridgeAttribute: deviceBringUpEmptyBridgeSchemaAttribute,
 		deviceDADTransmitsAttribute:       deviceDADTransmitsSchemaAttribute,
@@ -170,7 +170,7 @@ var (
 		lucirpcglue.IdAttribute:           lucirpcglue.IdSchemaAttribute(deviceModelGetId, deviceModelSetId),
 	}
 
-	deviceTXQueueLengthSchemaAttribute = lucirpcglue.Int64SchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceTXQueueLengthSchemaAttribute = lucirpcglue.Int64SchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		Description:       deviceTXQueueLengthAttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(deviceModelSetTXQueueLength, deviceTXQueueLengthAttribute, deviceTXQueueLengthUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
@@ -180,7 +180,7 @@ var (
 		},
 	}
 
-	deviceTypeSchemaAttribute = lucirpcglue.StringSchemaAttribute[deviceModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	deviceTypeSchemaAttribute = lucirpcglue.StringSchemaAttribute[deviceModel, lucirpc.Options, lucirpc.Options]{
 		Description:       deviceTypeAttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(deviceModelSetType, deviceTypeAttribute, deviceTypeUCIOption),
 		ResourceExistence: lucirpcglue.Required,

--- a/openwrt/internal/network/device_acceptance_test.go
+++ b/openwrt/internal/network/device_acceptance_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"gotest.tools/v3/assert"
 )
 
@@ -22,7 +23,7 @@ func TestNetworkDeviceDataSourceAcceptance(t *testing.T) {
 		*dockerPool,
 		t,
 	)
-	options := map[string]json.RawMessage{
+	options := lucirpc.Options{
 		"name":  json.RawMessage(`"br-testing"`),
 		"ports": json.RawMessage(`["eth0", "eth1"]`),
 		"type":  json.RawMessage(`"bridge"`),

--- a/openwrt/internal/network/globals.go
+++ b/openwrt/internal/network/globals.go
@@ -1,11 +1,10 @@
 package network
 
 import (
-	"encoding/json"
-
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
@@ -23,20 +22,20 @@ const (
 )
 
 var (
-	globalsSchemaAttributes = map[string]lucirpcglue.SchemaAttribute[globalsModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	globalsSchemaAttributes = map[string]lucirpcglue.SchemaAttribute[globalsModel, lucirpc.Options, lucirpc.Options]{
 		globalsULAPrefixAttribute:      globalsULAPrefixSchemaAttribute,
 		globalsPacketSteeringAttribute: globalsPacketSteeringSchemaAttribute,
 		lucirpcglue.IdAttribute:        lucirpcglue.IdSchemaAttribute(globalsModelGetId, globalsModelSetId),
 	}
 
-	globalsULAPrefixSchemaAttribute = lucirpcglue.StringSchemaAttribute[globalsModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	globalsULAPrefixSchemaAttribute = lucirpcglue.StringSchemaAttribute[globalsModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "IPv6 ULA prefix for this device.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(globalsModelSetULAPrefix, globalsULAPrefixAttribute, globalsULAPrefixUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(globalsModelGetULAPrefix, globalsULAPrefixAttribute, globalsULAPrefixUCIOption),
 	}
 
-	globalsPacketSteeringSchemaAttribute = lucirpcglue.BoolSchemaAttribute[globalsModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	globalsPacketSteeringSchemaAttribute = lucirpcglue.BoolSchemaAttribute[globalsModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "Use every CPU to handle packet traffic.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionBool(globalsModelSetPacketSteering, globalsPacketSteeringAttribute, globalsPacketSteeringUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,

--- a/openwrt/internal/network/globals_acceptance_test.go
+++ b/openwrt/internal/network/globals_acceptance_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/joneshf/terraform-provider-openwrt/internal/acceptancetest"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"gotest.tools/v3/assert"
 )
 
@@ -22,7 +23,7 @@ func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 		*dockerPool,
 		t,
 	)
-	options := map[string]json.RawMessage{
+	options := lucirpc.Options{
 		"packet_steering": json.RawMessage("false"),
 		"ula_prefix":      json.RawMessage(`"fd12:3456:789a::/48"`),
 	}

--- a/openwrt/internal/system/system.go
+++ b/openwrt/internal/system/system.go
@@ -1,11 +1,10 @@
 package system
 
 import (
-	"encoding/json"
-
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
 	"github.com/joneshf/terraform-provider-openwrt/openwrt/internal/lucirpcglue"
 )
 
@@ -44,49 +43,49 @@ const (
 )
 
 var (
-	systemConLogLevelSchemaAttribute = lucirpcglue.Int64SchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	systemConLogLevelSchemaAttribute = lucirpcglue.Int64SchemaAttribute[systemModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "The maximum log level for kernel messages to be logged to the console.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(systemModelSetConLogLevel, systemConLogLevelAttribute, systemConLogLevelUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionInt64(systemModelGetConLogLevel, systemConLogLevelAttribute, systemConLogLevelUCIOption),
 	}
 
-	systemCronLogLevelSchemaAttribute = lucirpcglue.Int64SchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	systemCronLogLevelSchemaAttribute = lucirpcglue.Int64SchemaAttribute[systemModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "The minimum level for cron messages to be logged to syslog.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(systemModelSetCronLogLevel, systemCronLogLevelAttribute, systemCronLogLevelUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionInt64(systemModelGetCronLogLevel, systemCronLogLevelAttribute, systemCronLogLevelUCIOption),
 	}
 
-	systemDescriptionSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	systemDescriptionSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "The hostname for the system.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(systemModelSetDescription, systemDescriptionAttribute, systemDescriptionUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(systemModelGetDescription, systemDescriptionAttribute, systemDescriptionUCIOption),
 	}
 
-	systemHostnameSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	systemHostnameSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "A short single-line description for the system.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(systemModelSetHostname, systemHostnameAttribute, systemHostnameUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(systemModelGetHostname, systemHostnameAttribute, systemHostnameUCIOption),
 	}
 
-	systemLogSizeSchemaAttribute = lucirpcglue.Int64SchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	systemLogSizeSchemaAttribute = lucirpcglue.Int64SchemaAttribute[systemModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "Size of the file based log buffer in KiB.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(systemModelSetLogSize, systemLogSizeAttribute, systemLogSizeUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionInt64(systemModelGetLogSize, systemLogSizeAttribute, systemLogSizeUCIOption),
 	}
 
-	systemNotesSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	systemNotesSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "Multi-line free-form text about the system.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(systemModelSetNotes, systemNotesAttribute, systemNotesUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(systemModelGetNotes, systemNotesAttribute, systemNotesUCIOption),
 	}
 
-	systemSchemaAttributes = map[string]lucirpcglue.SchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	systemSchemaAttributes = map[string]lucirpcglue.SchemaAttribute[systemModel, lucirpc.Options, lucirpc.Options]{
 		lucirpcglue.IdAttribute:     lucirpcglue.IdSchemaAttribute(systemModelGetId, systemModelSetId),
 		systemConLogLevelAttribute:  systemConLogLevelSchemaAttribute,
 		systemCronLogLevelAttribute: systemCronLogLevelSchemaAttribute,
@@ -99,21 +98,21 @@ var (
 		systemZonenameAttribute:     systemZonenameSchemaAttribute,
 	}
 
-	systemTimezoneSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	systemTimezoneSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "The POSIX.1 time zone string. This has no corresponding value in LuCI. See: https://github.com/openwrt/luci/blob/cd82ccacef78d3bb8b8af6b87dabb9e892e2b2aa/modules/luci-base/luasrc/sys/zoneinfo/tzdata.lua.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(systemModelSetTimezone, systemTimezoneAttribute, systemTimezoneUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(systemModelGetTimezone, systemTimezoneAttribute, systemTimezoneUCIOption),
 	}
 
-	systemTtyLoginSchemaAttribute = lucirpcglue.BoolSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	systemTtyLoginSchemaAttribute = lucirpcglue.BoolSchemaAttribute[systemModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "Require authentication for local users to log in the system.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionBool(systemModelSetTTYLogin, systemTTYLoginAttribute, systemTTYLoginUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionBool(systemModelGetTTYLogin, systemTTYLoginAttribute, systemTTYLoginUCIOption),
 	}
 
-	systemZonenameSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, map[string]json.RawMessage, map[string]json.RawMessage]{
+	systemZonenameSchemaAttribute = lucirpcglue.StringSchemaAttribute[systemModel, lucirpc.Options, lucirpc.Options]{
 		Description:       "The IANA/Olson time zone string. This corresponds to \"Timezone\" in LuCI. See: https://github.com/openwrt/luci/blob/cd82ccacef78d3bb8b8af6b87dabb9e892e2b2aa/modules/luci-base/luasrc/sys/zoneinfo/tzdata.lua.",
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(systemModelSetZonename, systemZonenameAttribute, systemZonenameUCIOption),
 		ResourceExistence: lucirpcglue.NoValidation,


### PR DESCRIPTION
We can make things a little more understandable by giving this map a
name instead of sticking with the primitive implementation. This also
lets us start thinknig about how we might make the options easier to
work with.