### PR TITLE
Undo changes to server mocks

### DIFF
--- a/lucirpc/client_test.go
+++ b/lucirpc/client_test.go
@@ -220,7 +220,7 @@ func TestClientCreateSection(t *testing.T) {
 			switch r.URL.Path {
 			case "/cgi-bin/luci/rpc/uci":
 				decoder := json.NewDecoder(r.Body)
-				var body lucirpc.Options
+				var body map[string]json.RawMessage
 				err := decoder.Decode(&body)
 				assert.NilError(t, err)
 				method, ok := body["method"]
@@ -451,7 +451,7 @@ func TestClientDeleteSection(t *testing.T) {
 			switch r.URL.Path {
 			case "/cgi-bin/luci/rpc/uci":
 				decoder := json.NewDecoder(r.Body)
-				var body lucirpc.Options
+				var body map[string]json.RawMessage
 				err := decoder.Decode(&body)
 				assert.NilError(t, err)
 				method, ok := body["method"]
@@ -1103,7 +1103,7 @@ func TestClientUpdateSection(t *testing.T) {
 			switch r.URL.Path {
 			case "/cgi-bin/luci/rpc/uci":
 				decoder := json.NewDecoder(r.Body)
-				var body lucirpc.Options
+				var body map[string]json.RawMessage
 				err := decoder.Decode(&body)
 				assert.NilError(t, err)
 				method, ok := body["method"]


### PR DESCRIPTION
We got a little carried away, and changed the types of the server mocks
in `lucirpc/client_test.go`. These `body`s are supposed to be plain
`map[string]json.RawMessage`s because they represent the underlying data
being sent to LuCI's JSON-RPC API. They don't represent the (slightly)
higher level interface of the options for a section.

We swap these back so we don't end up with hard to diagnose errors once
we add more behavior for section options.

The fact that we missed this is kind of showing that we probably
shouldn't be trying to mock these servers. We might consider dumping
these tests (or at least rewriting some of them), since they're actually
pretty hard to understand at this point.