### PR TITLE
Move `lucirpc.Options` to its own file

### DIFF
--- a/lucirpc/client.go
+++ b/lucirpc/client.go
@@ -438,10 +438,6 @@ func NewClient(
 	return client, nil
 }
 
-// Options are the actual UCI options for each section.
-// The values can be booleans, integers, lists, and strings.
-type Options map[string]json.RawMessage
-
 type jsonRPCClient struct {
 	address url.URL
 	client  http.Client

--- a/lucirpc/options.go
+++ b/lucirpc/options.go
@@ -1,0 +1,7 @@
+package lucirpc
+
+import "encoding/json"
+
+// Options are the actual UCI options for each section.
+// The values can be booleans, integers, lists, and strings.
+type Options map[string]json.RawMessage


### PR DESCRIPTION
It's about to get quite a bit more complex for options, so we're
separating it out to its own file to manage some of that complexity.