### PR TITLE
Type the LuCI JSON-RPC options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.8.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/ory/dockertest/v3 v3.9.1
+	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0
 	gotest.tools/v3 v3.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/lucirpc/client_acceptance_test.go
+++ b/lucirpc/client_acceptance_test.go
@@ -4,7 +4,6 @@ package lucirpc_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -91,9 +90,9 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 			"interface",
 			"testing",
 			lucirpc.Options{
-				"option_1": json.RawMessage("true"),
-				"option_2": json.RawMessage("31"),
-				"option_3": json.RawMessage(`["foo", "bar", "baz"]`),
+				"option_1": lucirpc.Boolean(true),
+				"option_2": lucirpc.Integer(31),
+				"option_3": lucirpc.ListString([]string{"foo", "bar", "baz"}),
 			},
 		)
 
@@ -106,12 +105,12 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 		)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, got, lucirpc.Options{
-			".anonymous": json.RawMessage("false"),
-			".name":      json.RawMessage(`"testing"`),
-			".type":      json.RawMessage(`"interface"`),
-			"option_1":   json.RawMessage(`"1"`),
-			"option_2":   json.RawMessage(`"31"`),
-			"option_3":   json.RawMessage(`["foo","bar","baz"]`),
+			".anonymous": lucirpc.Boolean(false),
+			".name":      lucirpc.String("testing"),
+			".type":      lucirpc.String("interface"),
+			"option_1":   lucirpc.Boolean(true),
+			"option_2":   lucirpc.Integer(31),
+			"option_3":   lucirpc.ListString([]string{"foo", "bar", "baz"}),
 		})
 	})
 
@@ -322,14 +321,14 @@ func TestClientGetSectionAcceptance(t *testing.T) {
 		// Then
 		assert.NilError(t, err)
 		want := lucirpc.Options{
-			".anonymous":   json.RawMessage("true"),
-			".name":        json.RawMessage(`"cfg01e48a"`),
-			".type":        json.RawMessage(`"system"`),
-			"hostname":     json.RawMessage(`"OpenWrt"`),
-			"log_size":     json.RawMessage(`"64"`),
-			"timezone":     json.RawMessage(`"UTC"`),
-			"ttylogin":     json.RawMessage(`"0"`),
-			"urandom_seed": json.RawMessage(`"0"`),
+			".anonymous":   lucirpc.Boolean(true),
+			".name":        lucirpc.String("cfg01e48a"),
+			".type":        lucirpc.String("system"),
+			"hostname":     lucirpc.String("OpenWrt"),
+			"log_size":     lucirpc.Integer(64),
+			"timezone":     lucirpc.String("UTC"),
+			"ttylogin":     lucirpc.Boolean(false),
+			"urandom_seed": lucirpc.Boolean(false),
 		}
 		assert.DeepEqual(t, got, want)
 	})
@@ -466,7 +465,7 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			"network",
 			"testing",
 			lucirpc.Options{
-				"foo": json.RawMessage("true"),
+				"foo": lucirpc.Boolean(true),
 			},
 		)
 
@@ -500,9 +499,9 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			"network",
 			"testing",
 			lucirpc.Options{
-				"option_1": json.RawMessage("true"),
-				"option_2": json.RawMessage("31"),
-				"option_3": json.RawMessage(`["foo", "bar", "baz"]`),
+				"option_1": lucirpc.Boolean(true),
+				"option_2": lucirpc.Integer(31),
+				"option_3": lucirpc.ListString([]string{"foo", "bar", "baz"}),
 			},
 		)
 
@@ -515,12 +514,12 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 		)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, got, lucirpc.Options{
-			".anonymous": json.RawMessage("false"),
-			".name":      json.RawMessage(`"testing"`),
-			".type":      json.RawMessage(`"interface"`),
-			"option_1":   json.RawMessage(`"1"`),
-			"option_2":   json.RawMessage(`"31"`),
-			"option_3":   json.RawMessage(`["foo","bar","baz"]`),
+			".anonymous": lucirpc.Boolean(false),
+			".name":      lucirpc.String("testing"),
+			".type":      lucirpc.String("interface"),
+			"option_1":   lucirpc.Boolean(true),
+			"option_2":   lucirpc.Integer(31),
+			"option_3":   lucirpc.ListString([]string{"foo", "bar", "baz"}),
 		})
 	})
 
@@ -549,9 +548,9 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 			"network",
 			"testing",
 			lucirpc.Options{
-				"option_1": json.RawMessage("true"),
-				"option_2": json.RawMessage("31"),
-				"option_3": json.RawMessage(`["foo", "bar", "baz"]`),
+				"option_1": lucirpc.Boolean(true),
+				"option_2": lucirpc.Integer(31),
+				"option_3": lucirpc.ListString([]string{"foo", "bar", "baz"}),
 			},
 		)
 

--- a/lucirpc/client_test.go
+++ b/lucirpc/client_test.go
@@ -726,9 +726,9 @@ func TestClientGetSection(t *testing.T) {
 		// Then
 		assert.NilError(t, err)
 		want := lucirpc.Options{
-			".name": json.RawMessage(`"section-name"`),
-			"baz":   json.RawMessage(`"1"`),
-			"foo":   json.RawMessage(`"bar"`),
+			".name": lucirpc.String("section-name"),
+			"baz":   lucirpc.Boolean(true),
+			"foo":   lucirpc.String("bar"),
 		}
 		assert.DeepEqual(t, got, want)
 	})

--- a/lucirpc/options.go
+++ b/lucirpc/options.go
@@ -1,7 +1,416 @@
 package lucirpc
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+// NewOptionNotFoundError constructs a new [OptionNotFoundError].
+// The `option` should be the option that wasn't found.
+// The `options` should be the options that were searched.
+func NewOptionNotFoundError(
+	option string,
+	options []string,
+) OptionNotFoundError {
+	return OptionNotFoundError{
+		option:  option,
+		options: options,
+	}
+}
+
+// NewOptionTypeMismatchError constructs a new [OptionTypeMismatchError].
+// It requires both the `actual` and `expected` types.
+func NewOptionTypeMismatchError(
+	expected string,
+	actual string,
+) OptionTypeMismatchError {
+	return OptionTypeMismatchError{
+		actual:   actual,
+		expected: expected,
+	}
+}
+
+// Option represents the different types of options that UCI supports.
+// They can be parsed from/serialized to JSON using [json.Unmarshal]/[json.Marshal], respectively.
+// They can also attempt to be serialized to the underlying Go value using the `As*` methods.
+//
+// To construct an [Option],
+// use one of [Boolean], [Integer], [ListString], or [String].
+type Option interface {
+	json.Marshaler
+	json.Unmarshaler
+	AsBoolean() (bool, error)
+	AsInteger() (int, error)
+	AsListString() ([]string, error)
+	AsString() (string, error)
+}
+
+// OptionNotFoundError represents an error finding the specified option.
+// It also communicates which options were searched.
+type OptionNotFoundError struct {
+	option  string
+	options []string
+}
+
+func (e OptionNotFoundError) Equal(other OptionNotFoundError) bool {
+	if e.option != other.option {
+		return false
+	}
+
+	slices.Sort(e.options)
+	slices.Sort(other.options)
+	return slices.Equal(e.options, e.options)
+}
+
+func (e OptionNotFoundError) Error() string {
+	options := []string{}
+	for _, option := range e.options {
+		options = append(options, fmt.Sprintf("%q", option))
+	}
+
+	combinedOptions := strings.Join(options, ", ")
+	return fmt.Sprintf("could not find option: %q; available options: %s", e.option, combinedOptions)
+}
+
+// OptionTypeMismatchError represents an error where the option was not the expected type.
+type OptionTypeMismatchError struct {
+	actual   string
+	expected string
+}
+
+func (e OptionTypeMismatchError) Equal(other OptionTypeMismatchError) bool {
+	return e.actual == other.actual &&
+		e.expected == other.expected
+}
+
+func (e OptionTypeMismatchError) Error() string {
+	return fmt.Sprintf("expected %s, but option is %s", e.expected, e.actual)
+}
 
 // Options are the actual UCI options for each section.
 // The values can be booleans, integers, lists, and strings.
-type Options map[string]json.RawMessage
+type Options map[string]Option
+
+// GetBoolean attempts to find the bool for the given option.
+//
+// The error could either be [NewOptionNotFoundError],
+// or one of the standard JSON errors.
+func (os Options) GetBoolean(option string) (bool, error) {
+	value, ok := os[option]
+	if !ok {
+		return false, NewOptionNotFoundError(option, maps.Keys(os))
+	}
+
+	return value.AsBoolean()
+}
+
+// GetInteger attempts to find the bool for the given option.
+//
+// The error could either be [NewOptionNotFoundError],
+// or one of the standard JSON errors.
+func (os Options) GetInteger(option string) (int, error) {
+	value, ok := os[option]
+	if !ok {
+		return 0, NewOptionNotFoundError(option, maps.Keys(os))
+	}
+
+	return value.AsInteger()
+}
+
+// GetListString attempts to find the bool for the given option.
+//
+// The error could either be [NewOptionNotFoundError],
+// or one of the standard JSON errors.
+func (os Options) GetListString(option string) ([]string, error) {
+	value, ok := os[option]
+	if !ok {
+		return nil, NewOptionNotFoundError(option, maps.Keys(os))
+	}
+
+	return value.AsListString()
+}
+
+// GetString attempts to find the bool for the given option.
+//
+// The error could either be [NewOptionNotFoundError],
+// or one of the standard JSON errors.
+func (os Options) GetString(option string) (string, error) {
+	value, ok := os[option]
+	if !ok {
+		return "", NewOptionNotFoundError(option, maps.Keys(os))
+	}
+
+	return value.AsString()
+}
+
+func (os *Options) UnmarshalJSON(raw []byte) error {
+	var options map[string]json.RawMessage
+	err := json.Unmarshal(raw, &options)
+	if err != nil {
+		return err
+	}
+
+	*os = map[string]Option{}
+	for option, rawValue := range options {
+		booleanValue := new(optionBoolean)
+		errBoolean := json.Unmarshal(rawValue, booleanValue)
+		if errBoolean == nil {
+			(*os)[option] = booleanValue
+			continue
+		}
+
+		integerValue := new(optionInteger)
+		errInteger := json.Unmarshal(rawValue, integerValue)
+		if errInteger == nil {
+			(*os)[option] = integerValue
+			continue
+		}
+
+		listStringValue := new(optionListString)
+		errListString := json.Unmarshal(rawValue, listStringValue)
+		if errListString == nil {
+			(*os)[option] = listStringValue
+			continue
+		}
+
+		stringValue := new(optionString)
+		errString := json.Unmarshal(rawValue, stringValue)
+		if errString == nil {
+			(*os)[option] = stringValue
+			continue
+		}
+
+		errAll := errors.Join(errBoolean, errInteger, errListString, errString)
+		err = errors.Join(err, fmt.Errorf("could not parse option %q: %w", option, errAll))
+	}
+
+	return err
+}
+
+type optionBoolean struct {
+	value bool
+}
+
+func (o *optionBoolean) AsBoolean() (bool, error) {
+	return o.value, nil
+}
+
+func (o *optionBoolean) AsInteger() (int, error) {
+	return 0, NewOptionTypeMismatchError("an integer", "a boolean")
+}
+
+func (o *optionBoolean) AsListString() ([]string, error) {
+	return nil, NewOptionTypeMismatchError("a list of strings", "a boolean")
+}
+
+func (o *optionBoolean) AsString() (string, error) {
+	return "", NewOptionTypeMismatchError("a string", "a boolean")
+}
+
+func (o *optionBoolean) Equal(other *optionBoolean) bool {
+	return o.value == other.value
+}
+
+func (o *optionBoolean) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.value)
+}
+
+// UnmarshalJSON attempts to convert raw JSON into a boolean.
+//
+// Boolean options in UCI can be any number of things:
+//   - True: "1", "yes", "on", "true", "enabled"
+//   - False: "0", "no", "off", "false", "disabled"
+//
+// Boolean options are stored in UCI as a string.
+// We try to parse one of these out of the raw JSON by first making sure it's a valid string.
+//
+// However, boolean metadata from LuCI's JSON-RPC API is returned as a JSON boolean.
+// We first try to parse the value as a normal JSON boolean,
+// in case it happens to be metadata.
+func (o *optionBoolean) UnmarshalJSON(raw []byte) error {
+	// First try to parse as a JSON boolean.
+	// We could be dealing with metadata.
+	var value bool
+	err := json.Unmarshal(raw, &value)
+	if err == nil {
+		o.value = value
+		return nil
+	}
+
+	// If that fails,
+	// Try to parse as a UCI boolean.
+	var boolish string
+	err = json.Unmarshal(raw, &boolish)
+	if err != nil {
+		return fmt.Errorf("could not convert to a string: %w", err)
+	}
+
+	switch boolish {
+	case "1", "yes", "on", "true", "enabled":
+		o.value = true
+		return nil
+
+	case "0", "no", "off", "false", "disabled":
+		o.value = false
+		return nil
+
+	default:
+		return fmt.Errorf(`expected one of "1", "yes", "on", "true", "enabled", "0", "no", "off", "false", or "disabled"; got: %q`, boolish)
+	}
+}
+
+// Boolean constructs a new [Option].
+func Boolean(value bool) *optionBoolean {
+	return &optionBoolean{
+		value: value,
+	}
+}
+
+type optionInteger struct {
+	value int
+}
+
+func (o *optionInteger) AsBoolean() (bool, error) {
+	return false, NewOptionTypeMismatchError("a boolean", "an integer")
+}
+
+func (o *optionInteger) AsInteger() (int, error) {
+	return o.value, nil
+}
+
+func (o *optionInteger) AsListString() ([]string, error) {
+	return nil, NewOptionTypeMismatchError("a list of strings", "an integer")
+}
+
+func (o *optionInteger) AsString() (string, error) {
+	return "", NewOptionTypeMismatchError("a string", "an integer")
+}
+
+func (o *optionInteger) Equal(other *optionInteger) bool {
+	return o.value == other.value
+}
+
+func (o *optionInteger) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.value)
+}
+
+// UnmarshalJSON attempts to convert raw JSON into an integer.
+//
+// Integers are stored in UCI as a string.
+// We try to parse one of these out of the raw JSON by first making sure it's a valid string.
+func (o *optionInteger) UnmarshalJSON(raw []byte) error {
+	var intish string
+	err := json.Unmarshal(raw, &intish)
+	if err != nil {
+		return fmt.Errorf("could not convert to a string: %w", err)
+	}
+
+	value, err := strconv.Atoi(intish)
+	if err != nil {
+		return fmt.Errorf("unable to parse as an integer: %w", err)
+	}
+
+	o.value = value
+	return nil
+}
+
+// Integer constructs a new [Option].
+func Integer(value int) *optionInteger {
+	return &optionInteger{
+		value: value,
+	}
+}
+
+type optionListString struct {
+	value []string
+}
+
+func (o *optionListString) AsBoolean() (bool, error) {
+	return false, NewOptionTypeMismatchError("a boolean", "a list of strings")
+}
+
+func (o *optionListString) AsInteger() (int, error) {
+	return 0, NewOptionTypeMismatchError("an integer", "a list of strings")
+}
+
+func (o *optionListString) AsListString() ([]string, error) {
+	return o.value, nil
+}
+
+func (o *optionListString) AsString() (string, error) {
+	return "", NewOptionTypeMismatchError("a string", "a list of strings")
+}
+
+func (o *optionListString) Equal(other *optionListString) bool {
+	if len(o.value) != len(other.value) {
+		return false
+	}
+
+	for i, value := range o.value {
+		if value != other.value[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (o *optionListString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.value)
+}
+
+func (o *optionListString) UnmarshalJSON(raw []byte) error {
+	return json.Unmarshal(raw, &o.value)
+}
+
+// ListString constructs a new [Option].
+func ListString(value []string) *optionListString {
+	return &optionListString{
+		value: value,
+	}
+}
+
+type optionString struct {
+	value string
+}
+
+func (o *optionString) AsBoolean() (bool, error) {
+	return false, NewOptionTypeMismatchError("a boolean", "a string")
+}
+
+func (o *optionString) AsInteger() (int, error) {
+	return 0, NewOptionTypeMismatchError("an integer", "a string")
+}
+
+func (o *optionString) AsListString() ([]string, error) {
+	return nil, NewOptionTypeMismatchError("a list of strings", "a string")
+}
+
+func (o *optionString) AsString() (string, error) {
+	return o.value, nil
+}
+
+func (o *optionString) Equal(other *optionString) bool {
+	return o.value == other.value
+}
+
+func (o *optionString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.value)
+}
+
+func (o *optionString) UnmarshalJSON(raw []byte) error {
+	return json.Unmarshal(raw, &o.value)
+}
+
+// String constructs a new [Option].
+func String(value string) *optionString {
+	return &optionString{
+		value: value,
+	}
+}

--- a/lucirpc/options_test.go
+++ b/lucirpc/options_test.go
@@ -1,0 +1,188 @@
+package lucirpc_test
+
+import (
+	"testing"
+
+	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
+	"gotest.tools/v3/assert"
+)
+
+func TestOptionsGetBoolean(t *testing.T) {
+	t.Run("errors with no option", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{}
+
+		// When
+		_, err := options.GetBoolean("option1")
+
+		// Then
+		want := lucirpc.NewOptionNotFoundError("option1", []string{})
+		assert.DeepEqual(t, err, want)
+	})
+
+	t.Run("errors with wrong type", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{
+			"option1": lucirpc.Integer(0),
+		}
+
+		// When
+		_, err := options.GetBoolean("option1")
+
+		// Then
+		want := lucirpc.NewOptionTypeMismatchError("a boolean", "an integer")
+		assert.DeepEqual(t, err, want)
+	})
+
+	t.Run("returns correct option", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{
+			"option1": lucirpc.Boolean(true),
+		}
+
+		// When
+		got, err := options.GetBoolean("option1")
+
+		// Then
+		want := true
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got, want)
+	})
+}
+
+func TestOptionsGetInteger(t *testing.T) {
+	t.Run("errors with no option", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{}
+
+		// When
+		_, err := options.GetInteger("option1")
+
+		// Then
+		want := lucirpc.NewOptionNotFoundError("option1", []string{})
+		assert.DeepEqual(t, err, want)
+	})
+
+	t.Run("errors with wrong type", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{
+			"option1": lucirpc.Boolean(false),
+		}
+
+		// When
+		_, err := options.GetInteger("option1")
+
+		// Then
+		want := lucirpc.NewOptionTypeMismatchError("an integer", "a boolean")
+		assert.DeepEqual(t, err, want)
+	})
+
+	t.Run("returns correct option", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{
+			"option1": lucirpc.Integer(31),
+		}
+
+		// When
+		got, err := options.GetInteger("option1")
+
+		// Then
+		want := 31
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got, want)
+	})
+}
+
+func TestOptionsGetListString(t *testing.T) {
+	t.Run("errors with no option", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{}
+
+		// When
+		_, err := options.GetListString("option1")
+
+		// Then
+		want := lucirpc.NewOptionNotFoundError("option1", []string{})
+		assert.DeepEqual(t, err, want)
+	})
+
+	t.Run("errors with wrong type", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{
+			"option1": lucirpc.Boolean(false),
+		}
+
+		// When
+		_, err := options.GetListString("option1")
+
+		// Then
+		want := lucirpc.NewOptionTypeMismatchError("a list of strings", "a boolean")
+		assert.DeepEqual(t, err, want)
+	})
+
+	t.Run("returns correct option", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{
+			"option1": lucirpc.ListString([]string{
+				"value1",
+				"value2",
+				"value3",
+			}),
+		}
+
+		// When
+		got, err := options.GetListString("option1")
+
+		// Then
+		want := []string{
+			"value1",
+			"value2",
+			"value3",
+		}
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got, want)
+	})
+}
+
+func TestOptionsGetString(t *testing.T) {
+	t.Run("errors with no option", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{}
+
+		// When
+		_, err := options.GetString("option1")
+
+		// Then
+		want := lucirpc.NewOptionNotFoundError("option1", []string{})
+		assert.DeepEqual(t, err, want)
+	})
+
+	t.Run("errors with wrong type", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{
+			"option1": lucirpc.Boolean(false),
+		}
+
+		// When
+		_, err := options.GetString("option1")
+
+		// Then
+		want := lucirpc.NewOptionTypeMismatchError("a string", "a boolean")
+		assert.DeepEqual(t, err, want)
+	})
+
+	t.Run("returns correct option", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{
+			"option1": lucirpc.String("hello"),
+		}
+
+		// When
+		got, err := options.GetString("option1")
+
+		// Then
+		want := "hello"
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got, want)
+	})
+}

--- a/lucirpc/options_test.go
+++ b/lucirpc/options_test.go
@@ -1,6 +1,7 @@
 package lucirpc_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/joneshf/terraform-provider-openwrt/lucirpc"
@@ -184,5 +185,96 @@ func TestOptionsGetString(t *testing.T) {
 		want := "hello"
 		assert.NilError(t, err)
 		assert.DeepEqual(t, got, want)
+	})
+}
+
+func TestOptionsMarshalJSON(t *testing.T) {
+	t.Run("works for all types", func(t *testing.T) {
+		// Given
+		options := lucirpc.Options{
+			"option1": lucirpc.Boolean(true),
+			"option2": lucirpc.Boolean(false),
+			"option3": lucirpc.Integer(31),
+			"option4": lucirpc.String("hello"),
+			"option5": lucirpc.ListString([]string{
+				"value1",
+				"value2",
+				"value3",
+			}),
+		}
+
+		// When
+		got, err := json.MarshalIndent(options, "\t\t", "\t")
+
+		// Then
+		want := []byte(`{
+			"option1": true,
+			"option2": false,
+			"option3": 31,
+			"option4": "hello",
+			"option5": [
+				"value1",
+				"value2",
+				"value3"
+			]
+		}`)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got, want)
+	})
+}
+
+func TestOptionsUnmarshalJSON(t *testing.T) {
+	t.Run("works for all types", func(t *testing.T) {
+		// Given
+		var options lucirpc.Options
+		rawJSON := `{
+			"option1": true,
+			"option2": "1",
+			"option3": "yes",
+			"option4": "on",
+			"option5": "true",
+			"option6": "enabled",
+			"option7": false,
+			"option8": "0",
+			"option9": "no",
+			"option10": "off",
+			"option11": "false",
+			"option12": "disabled",
+			"option13": "31",
+			"option14": "hello",
+			"option15": [
+				"value1",
+				"value2",
+				"value3"
+			]
+		}`
+
+		// When
+		err := json.Unmarshal([]byte(rawJSON), &options)
+
+		// Then
+		want := lucirpc.Options{
+			"option1":  lucirpc.Boolean(true),
+			"option2":  lucirpc.Boolean(true),
+			"option3":  lucirpc.Boolean(true),
+			"option4":  lucirpc.Boolean(true),
+			"option5":  lucirpc.Boolean(true),
+			"option6":  lucirpc.Boolean(true),
+			"option7":  lucirpc.Boolean(false),
+			"option8":  lucirpc.Boolean(false),
+			"option9":  lucirpc.Boolean(false),
+			"option10": lucirpc.Boolean(false),
+			"option11": lucirpc.Boolean(false),
+			"option12": lucirpc.Boolean(false),
+			"option13": lucirpc.Integer(31),
+			"option14": lucirpc.String("hello"),
+			"option15": lucirpc.ListString([]string{
+				"value1",
+				"value2",
+				"value3",
+			}),
+		}
+		assert.NilError(t, err)
+		assert.DeepEqual(t, options, want)
 	})
 }

--- a/openwrt/internal/lucirpcglue/metadata.go
+++ b/openwrt/internal/lucirpcglue/metadata.go
@@ -2,7 +2,6 @@ package lucirpcglue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -22,13 +21,7 @@ func GetMetadataString(
 ) (context.Context, types.String, diag.Diagnostics) {
 	diagnostics := diag.Diagnostics{}
 	result := types.StringNull()
-	raw, ok := section[key]
-	if !ok {
-		return ctx, result, diagnostics
-	}
-
-	var value string
-	err := json.Unmarshal(raw, &value)
+	value, err := section.GetString(key)
 	if err != nil {
 		diagnostics.AddError(
 			fmt.Sprintf("unable to parse metadata: %q", key),

--- a/openwrt/internal/network/device_acceptance_test.go
+++ b/openwrt/internal/network/device_acceptance_test.go
@@ -4,7 +4,6 @@ package network_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -24,9 +23,9 @@ func TestNetworkDeviceDataSourceAcceptance(t *testing.T) {
 		t,
 	)
 	options := lucirpc.Options{
-		"name":  json.RawMessage(`"br-testing"`),
-		"ports": json.RawMessage(`["eth0", "eth1"]`),
-		"type":  json.RawMessage(`"bridge"`),
+		"name":  lucirpc.String("br-testing"),
+		"ports": lucirpc.ListString([]string{"eth0", "eth1"}),
+		"type":  lucirpc.String("bridge"),
 	}
 	ok, err := client.CreateSection(ctx, "network", "device", "br_testing", options)
 	assert.NilError(t, err)

--- a/openwrt/internal/network/globals_acceptance_test.go
+++ b/openwrt/internal/network/globals_acceptance_test.go
@@ -4,7 +4,6 @@ package network_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -24,8 +23,8 @@ func TestNetworkGlobalsDataSourceAcceptance(t *testing.T) {
 		t,
 	)
 	options := lucirpc.Options{
-		"packet_steering": json.RawMessage("false"),
-		"ula_prefix":      json.RawMessage(`"fd12:3456:789a::/48"`),
+		"packet_steering": lucirpc.Boolean(false),
+		"ula_prefix":      lucirpc.String("fd12:3456:789a::/48"),
 	}
 	ok, err := client.CreateSection(ctx, "network", "globals", "globals", options)
 	assert.NilError(t, err)


### PR DESCRIPTION
We want a little more help doing the right thing here. We make a case
for each of the different types of options, and use that as the
interface for LuCI's JSON-RPC options.

This change makes it so the logic of how to deal with UCI's
representation of data types stays closer to the LuCI JSON-RPC API. We
probably should have done this from the beginning. Better late than
never, though.