### PR TITLE
Add `jq` to the environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
             pkgs.go-tools
             pkgs.gopls
             pkgs.goreleaser
+            pkgs.jq
             pkgs.nixpkgs-fmt
             pkgs.terraform
           ];


### PR DESCRIPTION
We use `jq` quite a bit when testing stuff. Might as well add it to the
environment.