### PR TITLE
Fix `peerdns` attribute

### DIFF
--- a/openwrt/internal/network/interface.go
+++ b/openwrt/internal/network/interface.go
@@ -224,13 +224,15 @@ var (
 		ResourceExistence: lucirpcglue.NoValidation,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionBool(interfaceModelGetPeerDNS, interfacePeerDNSAttribute, interfacePeerDNSUCIOption),
 		Validators: []validator.Bool{
-			lucirpcglue.RequiresAttributeEqualString(
-				path.MatchRoot(interfaceProtocolAttribute),
-				interfaceProtocolDHCP,
-			),
-			lucirpcglue.RequiresAttributeEqualString(
-				path.MatchRoot(interfaceProtocolAttribute),
-				interfaceProtocolDHCPV6,
+			lucirpcglue.AnyBool(
+				lucirpcglue.RequiresAttributeEqualString(
+					path.MatchRoot(interfaceProtocolAttribute),
+					interfaceProtocolDHCP,
+				),
+				lucirpcglue.RequiresAttributeEqualString(
+					path.MatchRoot(interfaceProtocolAttribute),
+					interfaceProtocolDHCPV6,
+				),
 			),
 		},
 	}

--- a/openwrt/internal/network/interface_acceptance_test.go
+++ b/openwrt/internal/network/interface_acceptance_test.go
@@ -134,3 +134,89 @@ resource "openwrt_network_interface" "testing" {
 		updateAndReadResource,
 	)
 }
+
+func TestNetworkInterfaceResourcePeerDNSWithDHCPAcceptance(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+		ctx,
+		*dockerPool,
+		t,
+	)
+
+	step := resource.TestStep{
+		Config: fmt.Sprintf(`
+%s
+
+resource "openwrt_network_interface" "testing" {
+	device = "br-testing"
+	dns = [
+		"9.9.9.9",
+		"1.1.1.1",
+	]
+	id = "testing"
+	peerdns = false
+	proto = "dhcp"
+}
+`,
+			providerBlock,
+		),
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "id", "testing"),
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "device", "br-testing"),
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "dns.0", "9.9.9.9"),
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "dns.1", "1.1.1.1"),
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "peerdns", "false"),
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "proto", "dhcp"),
+		),
+	}
+
+	acceptancetest.TerraformSteps(
+		t,
+		step,
+	)
+}
+
+func TestNetworkInterfaceResourcePeerDNSWithDHCPV6Acceptance(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+		ctx,
+		*dockerPool,
+		t,
+	)
+
+	step := resource.TestStep{
+		Config: fmt.Sprintf(`
+%s
+
+resource "openwrt_network_interface" "testing" {
+	device = "br-testing"
+	dns = [
+		"9.9.9.9",
+		"1.1.1.1",
+	]
+	id = "testing"
+	peerdns = false
+	proto = "dhcpv6"
+}
+`,
+			providerBlock,
+		),
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "id", "testing"),
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "device", "br-testing"),
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "dns.0", "9.9.9.9"),
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "dns.1", "1.1.1.1"),
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "peerdns", "false"),
+			resource.TestCheckResourceAttr("openwrt_network_interface.testing", "proto", "dhcpv6"),
+		),
+	}
+
+	acceptancetest.TerraformSteps(
+		t,
+		step,
+	)
+}


### PR DESCRIPTION
The way we setup `peerdns` isn't correct. We don't want to require both
that the `proto` be `"dhcp"` and `"dhcpv6"`. That doesn't even make
sense. And the fact that we can say that makes even less sense.

In order to show the failure, we add a failing test. We then implement a
fix by adding a validator that disjoins multiple other validators. The
test is effectively what we want in reality, so it passing here should
give good confidence that we can do what we want.

It's unfortunate that we have to write this validator. Hopefully, it's
an oversight and not intentional. We don't want to maintain this
indefinitely. See
https://github.com/hashicorp/terraform-plugin-framework-validators/issues/122
for the upstream issue.