### PR TITLE
Add a `make` target to release a new patch version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ CACHE_DIRECTORY := .cache
 build:
 	go build ./...
 
+.PHONY: bump-patch-version
+bump-patch-version:
+	./scripts/bump-patch-version.sh
+
 .PHONY: clean
 clean: clean-acceptance-test-server clean-cache-directory
 

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             pkgs.goreleaser
             pkgs.jq
             pkgs.nixpkgs-fmt
+            pkgs.semver
             pkgs.terraform
           ];
         };

--- a/scripts/bump-patch-version.sh
+++ b/scripts/bump-patch-version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+IFS=$'\n\t'
+
+# Generate the next version.
+readonly next_version=$(semver patch)
+
+# Generate a tag.
+git tag "${next_version}"
+
+# Push the tag
+git push origin "${next_version}"


### PR DESCRIPTION
We want to make things a little easier to deal with. So we add a `make`
target that lets us release a new patch version easily.

Since patch versions are the only bumping we've been doing, we only add
support for bumping patch versions. We can add support for other
versions when we get to that point.