### PR TITLE
Move the other attributes into OpenWrt struct

### DIFF
--- a/internal/acceptancetest/helpers.go
+++ b/internal/acceptancetest/helpers.go
@@ -30,10 +30,6 @@ const (
 	acceptanceTestDockerTag        = "acceptance-test"
 
 	dockerContainerHealthy = "healthy"
-
-	Password = ""
-	Scheme   = "http"
-	Username = "root"
 )
 
 var (
@@ -53,11 +49,11 @@ func AuthenticatedClient(
 	openWrtServer := RunOpenWrtServer(ctx, dockerPool, t)
 	client, err := lucirpc.NewClient(
 		ctx,
-		Scheme,
+		openWrtServer.Scheme,
 		openWrtServer.Hostname,
 		openWrtServer.HTTPPort,
-		Username,
-		Password,
+		openWrtServer.Username,
+		openWrtServer.Password,
 	)
 	assert.NilError(t, err)
 	return client
@@ -76,11 +72,11 @@ func AuthenticatedClientWithProviderBlock(
 	openWrtServer := RunOpenWrtServer(ctx, dockerPool, t)
 	client, err := lucirpc.NewClient(
 		ctx,
-		Scheme,
+		openWrtServer.Scheme,
 		openWrtServer.Hostname,
 		openWrtServer.HTTPPort,
-		Username,
-		Password,
+		openWrtServer.Username,
+		openWrtServer.Password,
 	)
 	assert.NilError(t, err)
 	providerBlock = fmt.Sprintf(`
@@ -92,9 +88,9 @@ provider "openwrt" {
 }
 `,
 		openWrtServer.Hostname,
-		Password,
+		openWrtServer.Password,
 		openWrtServer.HTTPPort,
-		Username,
+		openWrtServer.Username,
 	)
 	return
 }
@@ -103,6 +99,9 @@ provider "openwrt" {
 type OpenWrtServer struct {
 	Hostname string
 	HTTPPort uint16
+	Password string
+	Scheme   string
+	Username string
 }
 
 // RunOpenWrtServer constructs a running OpenWrt server.
@@ -134,6 +133,9 @@ func RunOpenWrtServer(
 	return OpenWrtServer{
 		Hostname: hostname,
 		HTTPPort: httpPort,
+		Password: "",
+		Scheme:   "http",
+		Username: "root",
 	}
 }
 
@@ -156,9 +158,9 @@ provider "openwrt" {
 }
 `,
 		openWrtServer.Hostname,
-		Password,
+		openWrtServer.Password,
 		openWrtServer.HTTPPort,
-		Username,
+		openWrtServer.Username,
 	)
 
 	return providerBlock

--- a/lucirpc/client_acceptance_test.go
+++ b/lucirpc/client_acceptance_test.go
@@ -369,11 +369,11 @@ func TestNewClientAcceptance(t *testing.T) {
 		// When
 		_, err := lucirpc.NewClient(
 			ctx,
-			acceptancetest.Scheme,
+			openWrtServer.Scheme,
 			openWrtServer.Hostname,
 			openWrtServer.HTTPPort,
-			acceptancetest.Username,
-			acceptancetest.Password,
+			openWrtServer.Username,
+			openWrtServer.Password,
 		)
 
 		// Then

--- a/openwrt/provider_acceptance_test.go
+++ b/openwrt/provider_acceptance_test.go
@@ -74,10 +74,10 @@ func TestOpenWrtProviderConfigureConnectsWithoutError(t *testing.T) {
 			},
 			map[string]tftypes.Value{
 				"hostname": tftypes.NewValue(tftypes.String, openWrtServer.Hostname),
-				"password": tftypes.NewValue(tftypes.String, acceptancetest.Password),
+				"password": tftypes.NewValue(tftypes.String, openWrtServer.Password),
 				"port":     tftypes.NewValue(tftypes.Number, openWrtServer.HTTPPort),
-				"scheme":   tftypes.NewValue(tftypes.String, acceptancetest.Scheme),
-				"username": tftypes.NewValue(tftypes.String, acceptancetest.Username),
+				"scheme":   tftypes.NewValue(tftypes.String, openWrtServer.Scheme),
+				"username": tftypes.NewValue(tftypes.String, openWrtServer.Username),
 			},
 		),
 	}
@@ -105,10 +105,10 @@ func TestOpenWrtProviderConfigureConnectsWithoutErrorWithEnvironmentVariables(t 
 	)
 	env := map[string]string{
 		"OPENWRT_HOSTNAME": openWrtServer.Hostname,
-		"OPENWRT_PASSWORD": acceptancetest.Password,
+		"OPENWRT_PASSWORD": openWrtServer.Password,
 		"OPENWRT_PORT":     strconv.Itoa(int(openWrtServer.HTTPPort)),
-		"OPENWRT_SCHEME":   acceptancetest.Scheme,
-		"OPENWRT_USERNAME": acceptancetest.Username,
+		"OPENWRT_SCHEME":   openWrtServer.Scheme,
+		"OPENWRT_USERNAME": openWrtServer.Username,
 	}
 	lookupEnv := func(key string) (string, bool) {
 		value, ok := env[key]


### PR DESCRIPTION
We had a weird split between stuff that was global to the
`acceptancetest` package, and local to the OpenWrt server. Instead of
keeping the two separate, we move all of those other attributes into the
OpenWrt server struct. It's irrelevant that they're always the same
value. The important part is that it's consistent.