### PR TITLE
Close the response body

### DIFF
--- a/lucirpc/client.go
+++ b/lucirpc/client.go
@@ -491,6 +491,7 @@ func (c jsonRPCClient) Invoke(
 		return nil, fmt.Errorf("problem sending request to %s: %w", humanReadableMethod, err)
 	}
 
+	defer response.Body.Close()
 	if response.StatusCode != 200 {
 		return nil, fmt.Errorf("expected %s to respond with a 200: got %s", humanReadableMethod, response.Status)
 	}


### PR DESCRIPTION
We missed this when we first added support for the JSON-RPC client. We
add it now, so we're not leaking memory anymore.