### PR TITLE
Move LuCI JSON-RPC client to `OpenWrtServer`

### DIFF
--- a/lucirpc/client_acceptance_test.go
+++ b/lucirpc/client_acceptance_test.go
@@ -27,9 +27,13 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 
@@ -52,9 +56,13 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 
@@ -77,9 +85,13 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 
@@ -119,9 +131,13 @@ func TestClientCreateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 
@@ -153,9 +169,13 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 
@@ -176,9 +196,13 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 		_, err := client.CreateSection(
@@ -207,9 +231,13 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 		_, err := client.CreateSection(
@@ -243,9 +271,13 @@ func TestClientDeleteSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 		_, err := client.CreateSection(
@@ -283,9 +315,13 @@ func TestClientGetSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 
@@ -305,9 +341,13 @@ func TestClientGetSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 
@@ -389,9 +429,13 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 
@@ -413,9 +457,13 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 		_, err := client.CreateSection(
@@ -445,9 +493,13 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 		_, err := client.CreateSection(
@@ -479,9 +531,13 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 		_, err := client.CreateSection(
@@ -528,9 +584,13 @@ func TestClientUpdateSectionAcceptance(t *testing.T) {
 
 		// Given
 		ctx := context.Background()
-		client := acceptancetest.AuthenticatedClient(
+		openWrtServer := acceptancetest.RunOpenWrtServer(
 			ctx,
 			*dockerPool,
+			t,
+		)
+		client := openWrtServer.LuCIRPCClient(
+			ctx,
 			t,
 		)
 		_, err := client.CreateSection(

--- a/openwrt/network/device/device_acceptance_test.go
+++ b/openwrt/network/device/device_acceptance_test.go
@@ -17,11 +17,16 @@ func TestDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	client, providerBlock := acceptancetest.AuthenticatedClientWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	client := openWrtServer.LuCIRPCClient(
+		ctx,
+		t,
+	)
+	providerBlock := openWrtServer.ProviderBlock()
 	options := lucirpc.Options{
 		"name":  lucirpc.String("br-testing"),
 		"ports": lucirpc.ListString([]string{"eth0", "eth1"}),
@@ -60,11 +65,12 @@ func TestResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	createAndReadResource := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/network/globals/globals_acceptance_test.go
+++ b/openwrt/network/globals/globals_acceptance_test.go
@@ -17,11 +17,16 @@ func TestDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	client, providerBlock := acceptancetest.AuthenticatedClientWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	client := openWrtServer.LuCIRPCClient(
+		ctx,
+		t,
+	)
+	providerBlock := openWrtServer.ProviderBlock()
 	options := lucirpc.Options{
 		"packet_steering": lucirpc.Boolean(false),
 		"ula_prefix":      lucirpc.String("fd12:3456:789a::/48"),
@@ -57,11 +62,12 @@ func TestResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	createAndReadResource := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/network/networkinterface/interface_acceptance_test.go
+++ b/openwrt/network/networkinterface/interface_acceptance_test.go
@@ -17,11 +17,16 @@ func TestDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	client, providerBlock := acceptancetest.AuthenticatedClientWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	client := openWrtServer.LuCIRPCClient(
+		ctx,
+		t,
+	)
+	providerBlock := openWrtServer.ProviderBlock()
 	options := lucirpc.Options{
 		"device":  lucirpc.String("br-testing"),
 		"ipaddr":  lucirpc.String("192.168.3.1"),
@@ -61,11 +66,12 @@ func TestResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	createAndReadResource := resource.TestStep{
 		Config: fmt.Sprintf(`
@@ -139,11 +145,12 @@ func TestResourcePeerDNSWithDHCPAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	step := resource.TestStep{
 		Config: fmt.Sprintf(`
@@ -182,11 +189,12 @@ func TestResourcePeerDNSWithDHCPV6Acceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	step := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/network/networkswitch/switch_acceptance_test.go
+++ b/openwrt/network/networkswitch/switch_acceptance_test.go
@@ -17,11 +17,16 @@ func TestDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	client, providerBlock := acceptancetest.AuthenticatedClientWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	client := openWrtServer.LuCIRPCClient(
+		ctx,
+		t,
+	)
+	providerBlock := openWrtServer.ProviderBlock()
 	options := lucirpc.Options{
 		"name":        lucirpc.String("switch0"),
 		"enable_vlan": lucirpc.Boolean(true),
@@ -57,11 +62,12 @@ func TestResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	createAndReadResource := resource.TestStep{
 		Config: fmt.Sprintf(`
@@ -116,11 +122,12 @@ func TestResourceMirrorMonitorPortWithEnableMirrorReceivedAcceptance(t *testing.
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	step := resource.TestStep{
 		Config: fmt.Sprintf(`
@@ -153,11 +160,12 @@ func TestResourceMirrorMonitorPortWithEnableMirrorTransmittedAcceptance(t *testi
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	step := resource.TestStep{
 		Config: fmt.Sprintf(`
@@ -190,11 +198,12 @@ func TestResourceMirrorSourcePortWithEnableMirrorReceivedAcceptance(t *testing.T
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	step := resource.TestStep{
 		Config: fmt.Sprintf(`
@@ -227,11 +236,12 @@ func TestResourceMirrorSourcePortWithEnableMirrorTransmittedAcceptance(t *testin
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	step := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/network/switchvlan/switch_vlan_acceptance_test.go
+++ b/openwrt/network/switchvlan/switch_vlan_acceptance_test.go
@@ -17,11 +17,16 @@ func TestDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	client, providerBlock := acceptancetest.AuthenticatedClientWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	client := openWrtServer.LuCIRPCClient(
+		ctx,
+		t,
+	)
+	providerBlock := openWrtServer.ProviderBlock()
 	options := lucirpc.Options{
 		"device": lucirpc.String("switch0"),
 		"ports":  lucirpc.String("0t 1t"),
@@ -61,11 +66,12 @@ func TestResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	createAndReadResource := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/system/system/system_acceptance_test.go
+++ b/openwrt/system/system/system_acceptance_test.go
@@ -15,11 +15,12 @@ func TestDataSourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	readDataSource := resource.TestStep{
 		Config: fmt.Sprintf(`
@@ -50,11 +51,12 @@ func TestResourceAcceptance(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	providerBlock := acceptancetest.RunOpenWrtServerWithProviderBlock(
+	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
 		*dockerPool,
 		t,
 	)
+	providerBlock := openWrtServer.ProviderBlock()
 
 	importValidation := resource.TestStep{
 		Config: fmt.Sprintf(`

--- a/openwrt/wireless/wifidevice/acceptance_test.go
+++ b/openwrt/wireless/wifidevice/acceptance_test.go
@@ -76,15 +76,10 @@ func runOpenWrtServerWithWireless(
 	})
 	err = session.Run("touch /etc/config/wireless")
 	assert.NilError(t, err)
-	client, err := lucirpc.NewClient(
+	client := openWrtServer.LuCIRPCClient(
 		ctx,
-		openWrtServer.Scheme,
-		openWrtServer.Hostname,
-		openWrtServer.HTTPPort,
-		openWrtServer.Username,
-		openWrtServer.Password,
+		t,
 	)
-	assert.NilError(t, err)
 	providerBlock := openWrtServer.ProviderBlock()
 	return client, providerBlock
 }


### PR DESCRIPTION
We had a couple of helpers to remove some of the bookkeeping of setting
up the tests. This seemed like a good idea at the time, but it meant
that we'd end up with awkward names for the helpers we made.

As we add more tests with different requirements, it's actually harder
to know what to use in each test with the helpers. So, we ditch them in
exchange for calling each thing explicitly.

This is a bit more work for each call-site, but it means that we don't
have to keep inventing new func names that don't accurately describe
what they're doing, or when to use them.