### PR TITLE
Fix UCI type for `wireless.wifi-device`

### DIFF
--- a/openwrt/internal/lucirpcglue/data_source.go
+++ b/openwrt/internal/lucirpcglue/data_source.go
@@ -3,6 +3,7 @@ package lucirpcglue
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -133,5 +134,7 @@ func (d *dataSource[Model]) Schema(
 func (d dataSource[Model]) getFullTypeName(
 	providerTypeName string,
 ) string {
-	return fmt.Sprintf("%s_%s_%s", providerTypeName, d.uciConfig, d.uciType)
+	uciConfig := strings.ReplaceAll(d.uciConfig, "-", "_")
+	uciType := strings.ReplaceAll(d.uciType, "-", "_")
+	return fmt.Sprintf("%s_%s_%s", providerTypeName, uciConfig, uciType)
 }

--- a/openwrt/internal/lucirpcglue/resource.go
+++ b/openwrt/internal/lucirpcglue/resource.go
@@ -3,6 +3,7 @@ package lucirpcglue
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	frameworkresource "github.com/hashicorp/terraform-plugin-framework/resource"
@@ -307,5 +308,7 @@ func (d *resource[Model]) Update(
 func (d resource[Model]) getFullTypeName(
 	providerTypeName string,
 ) string {
-	return fmt.Sprintf("%s_%s_%s", providerTypeName, d.uciConfig, d.uciType)
+	uciConfig := strings.ReplaceAll(d.uciConfig, "-", "_")
+	uciType := strings.ReplaceAll(d.uciType, "-", "_")
+	return fmt.Sprintf("%s_%s_%s", providerTypeName, uciConfig, uciType)
 }

--- a/openwrt/wireless/wifidevice/wifi_device.go
+++ b/openwrt/wireless/wifidevice/wifi_device.go
@@ -65,7 +65,7 @@ const (
 	typeUCIOption            = "type"
 
 	uciConfig = "wireless"
-	uciType   = "wifi_device"
+	uciType   = "wifi-device"
 )
 
 var (


### PR DESCRIPTION
This typo is everything that's wrong with UCI. There's no consistency in
the naming scheme. And, there's nothing stopping you from using the
incorrect UCI type. Nothing failed for any of the tests here because at
its core, UCI allows basically any config to have any name with any
section with any options. It's way too lenient, and it means that you
have to be extra careful whenever you're using it directly (like we're
doing here).

If there's a way to accurately test that we're using the correct thing,
we should switch to it. But, it's not clear how we'd actually catch a
mistake like this.

In any case, we fix this typo, so a `wireless.wifi-device` can actually
be created now.