### PR TITLE
Remove a lot of parallelism in the tests

### DIFF
--- a/openwrt/network/device/device_acceptance_test.go
+++ b/openwrt/network/device/device_acceptance_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestDataSourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -62,8 +60,6 @@ data "openwrt_network_device" "this" {
 }
 
 func TestResourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,

--- a/openwrt/network/globals/globals_acceptance_test.go
+++ b/openwrt/network/globals/globals_acceptance_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestDataSourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -59,8 +57,6 @@ data "openwrt_network_globals" "this" {
 }
 
 func TestResourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,

--- a/openwrt/network/networkinterface/interface_acceptance_test.go
+++ b/openwrt/network/networkinterface/interface_acceptance_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestDataSourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -63,8 +61,6 @@ data "openwrt_network_interface" "testing" {
 }
 
 func TestResourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -142,8 +138,6 @@ resource "openwrt_network_interface" "testing" {
 }
 
 func TestResourcePeerDNSWithDHCPAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -186,8 +180,6 @@ resource "openwrt_network_interface" "testing" {
 }
 
 func TestResourcePeerDNSWithDHCPV6Acceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,

--- a/openwrt/network/networkswitch/switch_acceptance_test.go
+++ b/openwrt/network/networkswitch/switch_acceptance_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestDataSourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -59,8 +57,6 @@ data "openwrt_network_switch" "testing" {
 }
 
 func TestResourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -119,8 +115,6 @@ resource "openwrt_network_switch" "testing" {
 }
 
 func TestResourceMirrorMonitorPortWithEnableMirrorReceivedAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -157,8 +151,6 @@ resource "openwrt_network_switch" "testing" {
 }
 
 func TestResourceMirrorMonitorPortWithEnableMirrorTransmittedAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -195,8 +187,6 @@ resource "openwrt_network_switch" "testing" {
 }
 
 func TestResourceMirrorSourcePortWithEnableMirrorReceivedAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -233,8 +223,6 @@ resource "openwrt_network_switch" "testing" {
 }
 
 func TestResourceMirrorSourcePortWithEnableMirrorTransmittedAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,

--- a/openwrt/network/switchvlan/switch_vlan_acceptance_test.go
+++ b/openwrt/network/switchvlan/switch_vlan_acceptance_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestDataSourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -63,8 +61,6 @@ data "openwrt_network_switch_vlan" "testing" {
 }
 
 func TestResourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,

--- a/openwrt/provider_acceptance_test.go
+++ b/openwrt/provider_acceptance_test.go
@@ -47,8 +47,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestOpenWrtProviderConfigureConnectsWithoutError(t *testing.T) {
-	t.Parallel()
-
 	// Given
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
@@ -94,8 +92,6 @@ func TestOpenWrtProviderConfigureConnectsWithoutError(t *testing.T) {
 }
 
 func TestOpenWrtProviderConfigureConnectsWithoutErrorWithEnvironmentVariables(t *testing.T) {
-	t.Parallel()
-
 	// Given
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(

--- a/openwrt/system/system/system_acceptance_test.go
+++ b/openwrt/system/system/system_acceptance_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestDataSourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,
@@ -48,8 +46,6 @@ data "openwrt_system_system" "this" {
 }
 
 func TestResourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	openWrtServer := acceptancetest.RunOpenWrtServer(
 		ctx,

--- a/openwrt/wireless/wifidevice/wifi_device_acceptance_test.go
+++ b/openwrt/wireless/wifidevice/wifi_device_acceptance_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestDataSourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	client, providerBlock := runOpenWrtServerWithWireless(
 		ctx,
@@ -54,8 +52,6 @@ data "openwrt_wireless_wifi_device" "testing" {
 }
 
 func TestResourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	_, providerBlock := runOpenWrtServerWithWireless(
 		ctx,

--- a/openwrt/wireless/wifiiface/wifi_iface_acceptance_test.go
+++ b/openwrt/wireless/wifiiface/wifi_iface_acceptance_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestDataSourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	client, providerBlock := runOpenWrtServerWithWireless(
 		ctx,
@@ -58,8 +56,6 @@ data "openwrt_wireless_wifi_iface" "testing" {
 }
 
 func TestResourceAcceptance(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	_, providerBlock := runOpenWrtServerWithWireless(
 		ctx,


### PR DESCRIPTION
The tests have gotten incredibly flaky over time. It's to the point that
it took eight attempts of the test job on the `main` branch to pass:
https://github.com/joneshf/terraform-provider-openwrt/actions/runs/4592301778.
That's too unreliable to be useful.

It's been pretty hard to diagnose what the issue is, but the best lead
we've got is that we're trying to run too many servers all at once, and
it's causing them to behave poorly. Since we're taking an educated guess
at the problem, the solution is also an educated guess: limit the
parallelism in the tests. This might not actually solve the issue for
us, but limited testing is showing that the tests succeed more often
than before.

If this doesn't work, we can always try something else. But we need to
start somewhere, and this seems like the most promising fix to make.