### PR TITLE
Improve CI performance

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,12 +55,13 @@ jobs:
         uses: actions/cache@v3.3.0
         with:
           # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
-          key: ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}
+          key: ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**.go') }}
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
           restore-keys: |
-            ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}
+            ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**.go') }}
+            ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}-
             ${{ runner.os }}-go-test-go-acceptance-test-
             ${{ runner.os }}-go-test-
             ${{ runner.os }}-go-
@@ -94,12 +95,13 @@ jobs:
         uses: actions/cache@v3.3.0
         with:
           # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
-          key: ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}
+          key: ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**.go') }}
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
           restore-keys: |
-            ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}
+            ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**.go') }}
+            ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}-
             ${{ runner.os }}-go-test-go-unit-test-
             ${{ runner.os }}-go-test-
             ${{ runner.os }}-go-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,8 @@ jobs:
             ~/go/pkg/mod
           restore-keys: |
             ${{ runner.os }}-go-docs-${{ hashfiles('go.mod', 'go.sum') }}
+            ${{ runner.os }}-go-docs-
+            ${{ runner.os }}-go-
       - name: Generate Documentation
         run: nix --store ~/nix develop . --command make docs
 
@@ -59,6 +61,9 @@ jobs:
             ~/go/pkg/mod
           restore-keys: |
             ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}
+            ${{ runner.os }}-go-test-go-acceptance-test-
+            ${{ runner.os }}-go-test-
+            ${{ runner.os }}-go-
       - name: Cache Docker Image
         uses: actions/cache@v3.3.0
         with:
@@ -95,5 +100,8 @@ jobs:
             ~/go/pkg/mod
           restore-keys: |
             ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}
+            ${{ runner.os }}-go-test-go-unit-test-
+            ${{ runner.os }}-go-test-
+            ${{ runner.os }}-go-
       - name: Run Unit Tests
         run: nix --store ~/nix develop . --command make test-go-unit-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Run Acceptance Tests
         run: nix --store ~/nix develop . --command make test-go-acceptance-test
         env:
-          GODEBUG: gocachetest=1
+          GODEBUG: gocachehash=1,gocachetest=1
 
   test-go-unit-test:
     runs-on: ubuntu-latest
@@ -110,4 +110,4 @@ jobs:
       - name: Run Unit Tests
         run: nix --store ~/nix develop . --command make test-go-unit-test
         env:
-          GODEBUG: gocachetest=1
+          GODEBUG: gocachehash=1,gocachetest=1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,8 @@ jobs:
             ${{ runner.os }}-docker-
       - name: Run Acceptance Tests
         run: nix --store ~/nix develop . --command make test-go-acceptance-test
+        env:
+          GODEBUG: gocachetest=1
 
   test-go-unit-test:
     runs-on: ubuntu-latest
@@ -107,3 +109,5 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run Unit Tests
         run: nix --store ~/nix develop . --command make test-go-unit-test
+        env:
+          GODEBUG: gocachetest=1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
       - "**"
 
 jobs:
-  documentation:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -21,7 +21,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
             ${{ runner.os }}-nix-
-      - name: Cache Go Integration Tests
+      - name: Cache Go Docs
         uses: actions/cache@v3.3.0
         with:
           # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
@@ -34,7 +34,7 @@ jobs:
       - name: Generate Documentation
         run: nix --store ~/nix develop . --command make docs
 
-  test-integration:
+  test-go-acceptance-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -49,16 +49,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
             ${{ runner.os }}-nix-
-      - name: Cache Go Integration Tests
+      - name: Cache Go Acceptance Tests
         uses: actions/cache@v3.3.0
         with:
           # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
-          key: ${{ runner.os }}-go-test-integration-${{ hashfiles('go.mod', 'go.sum') }}
+          key: ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
           restore-keys: |
-            ${{ runner.os }}-go-test-integration-${{ hashfiles('go.mod', 'go.sum') }}
+            ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}
       - name: Cache Docker Image
         uses: actions/cache@v3.3.0
         with:
@@ -67,10 +67,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-docker-${{ hashfiles('acceptance-test.Dockerfile', 'acceptance-test.Dockerfile.dockerignore') }}
             ${{ runner.os }}-docker-
-      - name: Run Integration Tests
-        run: nix --store ~/nix develop . --command make test-go-integration
+      - name: Run Acceptance Tests
+        run: nix --store ~/nix develop . --command make test-go-acceptance-test
 
-  test-unit:
+  test-go-unit-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -89,11 +89,11 @@ jobs:
         uses: actions/cache@v3.3.0
         with:
           # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
-          key: ${{ runner.os }}-go-test-unit-${{ hashfiles('go.mod', 'go.sum') }}
+          key: ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
           restore-keys: |
-            ${{ runner.os }}-go-test-unit-${{ hashfiles('go.mod', 'go.sum') }}
+            ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}
       - name: Run Unit Tests
-        run: nix --store ~/nix develop . --command make test-go-unit
+        run: nix --store ~/nix develop . --command make test-go-unit-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,12 +55,12 @@ jobs:
         uses: actions/cache@v3.3.0
         with:
           # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
-          key: ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**.go') }}
+          key: ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**/*.go') }}
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
           restore-keys: |
-            ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**.go') }}
+            ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**/*.go') }}
             ${{ runner.os }}-go-test-go-acceptance-test-${{ hashfiles('go.mod', 'go.sum') }}-
             ${{ runner.os }}-go-test-go-acceptance-test-
             ${{ runner.os }}-go-test-
@@ -97,12 +97,12 @@ jobs:
         uses: actions/cache@v3.3.0
         with:
           # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
-          key: ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**.go') }}
+          key: ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**/*.go') }}
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
           restore-keys: |
-            ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**.go') }}
+            ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}-${{ hashfiles('**/*.go') }}
             ${{ runner.os }}-go-test-go-unit-test-${{ hashfiles('go.mod', 'go.sum') }}-
             ${{ runner.os }}-go-test-go-unit-test-
             ${{ runner.os }}-go-test-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
       - "**"
 
 jobs:
-  test:
+  documentation:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -21,17 +21,44 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
             ${{ runner.os }}-nix-
-      - name: Cache Go
+      - name: Cache Go Integration Tests
         uses: actions/cache@v3.3.0
         with:
           # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
-          key: ${{ runner.os }}-go-${{ hashfiles('go.mod', 'go.sum') }}
+          key: ${{ runner.os }}-go-docs-${{ hashfiles('go.mod', 'go.sum') }}
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
           restore-keys: |
-            ${{ runner.os }}-go-${{ hashfiles('go.mod', 'go.sum') }}
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-docs-${{ hashfiles('go.mod', 'go.sum') }}
+      - name: Generate Documentation
+        run: nix --store ~/nix develop . --command make docs
+
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v19
+      - name: Cache Nix
+        uses: actions/cache@v3.3.0
+        with:
+          key: ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
+          path: ~/nix
+          restore-keys: |
+            ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
+            ${{ runner.os }}-nix-
+      - name: Cache Go Integration Tests
+        uses: actions/cache@v3.3.0
+        with:
+          # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
+          key: ${{ runner.os }}-go-test-integration-${{ hashfiles('go.mod', 'go.sum') }}
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          restore-keys: |
+            ${{ runner.os }}-go-test-integration-${{ hashfiles('go.mod', 'go.sum') }}
       - name: Cache Docker Image
         uses: actions/cache@v3.3.0
         with:
@@ -40,5 +67,33 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-docker-${{ hashfiles('acceptance-test.Dockerfile', 'acceptance-test.Dockerfile.dockerignore') }}
             ${{ runner.os }}-docker-
-      - name: Test
-        run: nix --store ~/nix develop . --command make test
+      - name: Run Integration Tests
+        run: nix --store ~/nix develop . --command make test-go-integration
+
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v19
+      - name: Cache Nix
+        uses: actions/cache@v3.3.0
+        with:
+          key: ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
+          path: ~/nix
+          restore-keys: |
+            ${{ runner.os }}-nix-${{ hashfiles('flake.lock', 'flake.nix') }}
+            ${{ runner.os }}-nix-
+      - name: Cache Go Unit Tests
+        uses: actions/cache@v3.3.0
+        with:
+          # We hash both `go.mod` in addition to `go.sum` because the version of go is only in `go.mod`.
+          key: ${{ runner.os }}-go-test-unit-${{ hashfiles('go.mod', 'go.sum') }}
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          restore-keys: |
+            ${{ runner.os }}-go-test-unit-${{ hashfiles('go.mod', 'go.sum') }}
+      - name: Run Unit Tests
+        run: nix --store ~/nix develop . --command make test-go-unit


### PR DESCRIPTION
CI is back to being slow again. Since removing a bunch of parallelism in
https://github.com/joneshf/terraform-provider-openwrt/pull/126, things
take a long time to run. Some of this is expected when there are large
changes. However, when adding a new Data Source/Resource, it seems like
the entire test suite runs again from scratch.

It seems like there should be some kind of caching in the tests that
isn't showing up, and it looks like it's due to the change in build
flags/environment variables used to run integration tests. Because we
use the same cache for all the tests, we end up doing something like:
1. Run the unit tests with one set of build flags/environment variables.
2. It creates a cached test run.
3. Run the integration tests a different set of build flags/environment
    variables. This causes the cached tests from the unit tests to be
    invalidated.
4. It creates a new cached test run.
5. In a future commit, run the unit tests with the original set of build
    flags/environment variables. This causes the cached tests from the
    integration tests to be invalidated.

Because we're always alternating between unit tests and integration
tests, the cached tests are never being used.

In order to address that, we're splitting the test jobs between
integration test and unit tests. We make a different cache for each job,
so they can reuse their cached tests when possible. This should allow
the tests to only run what has changed between commits, instead of
needing to re-run everything, all the time.