### PR TITLE
Add support for wireless.wifi-iface rekeying and MFP

### DIFF
--- a/acceptance-test.Dockerfile
+++ b/acceptance-test.Dockerfile
@@ -1,4 +1,4 @@
-FROM openwrtorg/rootfs:x86_64-22.03.3@sha256:bf650d3c71a5d31c51c50228c2991c6f41ef672080f911f28ce61e6ea4d54637
+FROM openwrt/rootfs:x86_64-22.03.3@sha256:42bfe5aded99ddfbde5b9ba4c91d0826069d34eef6b537a6a510a5c4edf9147b
 
 RUN mkdir /var/lock
 RUN opkg update && opkg install \
@@ -21,3 +21,7 @@ HEALTHCHECK --interval=5s CMD curl \
     --fail \
     --no-progress-meter \
     http://localhost/cgi-bin/luci/rpc/auth
+
+EXPOSE 80 22
+
+CMD ["/sbin/init"]

--- a/docs/data-sources/wireless_wifi_iface.md
+++ b/docs/data-sources/wireless_wifi_iface.md
@@ -29,11 +29,13 @@ data "openwrt_wireless_wifi_iface" "testing" {
 
 - `device` (String) Name of the physical device. This name is what the device is known as in LuCI/UCI, or the `id` field in Terraform.
 - `encryption` (String) Encryption method. Currently, only PSK encryption methods are supported. Must be one of: "none", "psk", "psk2", "psk2+aes", "psk2+ccmp", "psk2+tkip", "psk2+tkip+aes", "psk2+tkip+ccmp", "psk+aes", "psk+ccmp", "psk-mixed", "psk-mixed+aes", "psk-mixed+ccmp", "psk-mixed+tkip", "psk-mixed+tkip+aes", "psk-mixed+tkip+ccmp", "psk+tkip", "psk+tkip+aes", "psk+tkip+ccmp", "sae", "sae-mixed".
+- `ieee80211w` (Number) 802.11w management frame protection. Must be one of 0 (disabled), 1 (optional), or 2 (required). OpenWrt may override this for WPA3-related encryption modes.
 - `isolate` (Boolean) Isolate wireless clients from each other.
 - `key` (String, Sensitive) The pre-shared passphrase from which the pre-shared key will be derived. The clear text key has to be 8-63 characters long.
 - `mode` (String) The operation mode of the wireless network interface controller.. Currently only "ap" is supported.
 - `network` (String) Network interface to attach the wireless network. This name is what the interface is known as in UCI, or the `id` field in Terraform.
 - `ssid` (String) The broadcasted SSID of the wireless network. This is what actual clients will see the network as.
 - `wpa_disable_eapol_key_retries` (Boolean) Enable WPA key reinstallation attack (KRACK) workaround. This should be `true` to enable KRACK workaround (you almost surely want this enabled).
+- `wpa_group_rekey` (Number) WPA group key rekey interval in seconds. Must be at least 1.
 
 

--- a/docs/resources/wireless_wifi_iface.md
+++ b/docs/resources/wireless_wifi_iface.md
@@ -58,9 +58,11 @@ resource "openwrt_wireless_wifi_iface" "home" {
 ### Optional
 
 - `encryption` (String) Encryption method. Currently, only PSK encryption methods are supported. Must be one of: "none", "psk", "psk2", "psk2+aes", "psk2+ccmp", "psk2+tkip", "psk2+tkip+aes", "psk2+tkip+ccmp", "psk+aes", "psk+ccmp", "psk-mixed", "psk-mixed+aes", "psk-mixed+ccmp", "psk-mixed+tkip", "psk-mixed+tkip+aes", "psk-mixed+tkip+ccmp", "psk+tkip", "psk+tkip+aes", "psk+tkip+ccmp", "sae", "sae-mixed".
+- `ieee80211w` (Number) 802.11w management frame protection. Must be one of 0 (disabled), 1 (optional), or 2 (required). OpenWrt may override this for WPA3-related encryption modes.
 - `isolate` (Boolean) Isolate wireless clients from each other.
 - `key` (String, Sensitive) The pre-shared passphrase from which the pre-shared key will be derived. The clear text key has to be 8-63 characters long.
 - `wpa_disable_eapol_key_retries` (Boolean) Enable WPA key reinstallation attack (KRACK) workaround. This should be `true` to enable KRACK workaround (you almost surely want this enabled).
+- `wpa_group_rekey` (Number) WPA group key rekey interval in seconds. Must be at least 1.
 
 ## Import
 

--- a/openwrt/wireless/wifiiface/wifi_iface.go
+++ b/openwrt/wireless/wifiiface/wifi_iface.go
@@ -1,6 +1,7 @@
 package wifiiface
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -41,6 +42,13 @@ const (
 	encryptionMethodSAEMixed             = "sae-mixed"
 	encryptionMethodUCIOption            = "encryption"
 
+	ieee80211wAttribute            = "ieee80211w"
+	ieee80211wAttributeDescription = "802.11w management frame protection. Must be one of 0 (disabled), 1 (optional), or 2 (required). OpenWrt may override this for WPA3-related encryption modes."
+	ieee80211wDisabled             = 0
+	ieee80211wOptional             = 1
+	ieee80211wRequired             = 2
+	ieee80211wUCIOption            = "ieee80211w"
+
 	isolateClientsAttribute            = "isolate"
 	isolateClientsAttributeDescription = "Isolate wireless clients from each other."
 	isolateClientsUCIOption            = "isolate"
@@ -67,6 +75,10 @@ const (
 	ssidAttribute            = "ssid"
 	ssidAttributeDescription = "The broadcasted SSID of the wireless network. This is what actual clients will see the network as."
 	ssidUCIOption            = "ssid"
+
+	wpaGroupRekeyAttribute            = "wpa_group_rekey"
+	wpaGroupRekeyAttributeDescription = "WPA group key rekey interval in seconds. Must be at least 1."
+	wpaGroupRekeyUCIOption            = "wpa_group_rekey"
 
 	uciConfig = "wireless"
 	uciType   = "wifi-iface"
@@ -108,6 +120,24 @@ var (
 				encryptionMethodPSKTKIPCCMP,
 				encryptionMethodSAE,
 				encryptionMethodSAEMixed,
+			),
+		},
+	}
+
+	ieee80211wSchemaAttribute = lucirpcglue.Int64SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:       ieee80211wAttributeDescription,
+		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(modelSetIEEE80211W, ieee80211wAttribute, ieee80211wUCIOption),
+		ResourceExistence: lucirpcglue.NoValidation,
+		UpsertRequest:     lucirpcglue.UpsertRequestOptionInt64(modelGetIEEE80211W, ieee80211wAttribute, ieee80211wUCIOption),
+		Validators: []validator.Int64{
+			int64validator.OneOf(
+				ieee80211wDisabled,
+				ieee80211wOptional,
+				ieee80211wRequired,
+			),
+			lucirpcglue.RequiresAttributeEqualString(
+				path.MatchRoot(modeAttribute),
+				modeAP,
 			),
 		},
 	}
@@ -172,6 +202,7 @@ var (
 	schemaAttributes = map[string]lucirpcglue.SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
 		deviceAttribute:           deviceSchemaAttribute,
 		encryptionMethodAttribute: encryptionMethodSchemaAttribute,
+		ieee80211wAttribute:       ieee80211wSchemaAttribute,
 		isolateClientsAttribute:   isolateClientsSchemaAttribute,
 		keyAttribute:              keySchemaAttribute,
 		krackWorkaroundAttribute:  krackWorkaroundSchemaAttribute,
@@ -179,6 +210,7 @@ var (
 		modeAttribute:             modeSchemaAttribute,
 		networkAttribute:          networkSchemaAttribute,
 		ssidAttribute:             ssidSchemaAttribute,
+		wpaGroupRekeyAttribute:    wpaGroupRekeySchemaAttribute,
 	}
 
 	ssidSchemaAttribute = lucirpcglue.StringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
@@ -186,6 +218,20 @@ var (
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(modelSetSSID, ssidAttribute, ssidUCIOption),
 		ResourceExistence: lucirpcglue.Required,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(modelGetSSID, ssidAttribute, ssidUCIOption),
+	}
+
+	wpaGroupRekeySchemaAttribute = lucirpcglue.Int64SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:       wpaGroupRekeyAttributeDescription,
+		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(modelSetWPAGroupRekey, wpaGroupRekeyAttribute, wpaGroupRekeyUCIOption),
+		ResourceExistence: lucirpcglue.NoValidation,
+		UpsertRequest:     lucirpcglue.UpsertRequestOptionInt64(modelGetWPAGroupRekey, wpaGroupRekeyAttribute, wpaGroupRekeyUCIOption),
+		Validators: []validator.Int64{
+			int64validator.AtLeast(1),
+			lucirpcglue.RequiresAttributeEqualString(
+				path.MatchRoot(modeAttribute),
+				modeAP,
+			),
+		},
 	}
 )
 
@@ -212,6 +258,7 @@ func NewResource() resource.Resource {
 type model struct {
 	Device           types.String `tfsdk:"device"`
 	EncryptionMethod types.String `tfsdk:"encryption"`
+	IEEE80211W       types.Int64  `tfsdk:"ieee80211w"`
 	Id               types.String `tfsdk:"id"`
 	IsolateClients   types.Bool   `tfsdk:"isolate"`
 	Key              types.String `tfsdk:"key"`
@@ -219,10 +266,12 @@ type model struct {
 	Mode             types.String `tfsdk:"mode"`
 	Network          types.String `tfsdk:"network"`
 	SSID             types.String `tfsdk:"ssid"`
+	WPAGroupRekey    types.Int64  `tfsdk:"wpa_group_rekey"`
 }
 
 func modelGetDevice(m model) types.String           { return m.Device }
 func modelGetEncryptionMethod(m model) types.String { return m.EncryptionMethod }
+func modelGetIEEE80211W(m model) types.Int64        { return m.IEEE80211W }
 func modelGetId(m model) types.String               { return m.Id }
 func modelGetIsolateClients(m model) types.Bool     { return m.IsolateClients }
 func modelGetKey(m model) types.String              { return m.Key }
@@ -230,9 +279,11 @@ func modelGetKRACKWorkaround(m model) types.Bool    { return m.KRACKWorkaround }
 func modelGetMode(m model) types.String             { return m.Mode }
 func modelGetNetwork(m model) types.String          { return m.Network }
 func modelGetSSID(m model) types.String             { return m.SSID }
+func modelGetWPAGroupRekey(m model) types.Int64     { return m.WPAGroupRekey }
 
 func modelSetDevice(m *model, value types.String)           { m.Device = value }
 func modelSetEncryptionMethod(m *model, value types.String) { m.EncryptionMethod = value }
+func modelSetIEEE80211W(m *model, value types.Int64)        { m.IEEE80211W = value }
 func modelSetId(m *model, value types.String)               { m.Id = value }
 func modelSetIsolateClients(m *model, value types.Bool)     { m.IsolateClients = value }
 func modelSetKey(m *model, value types.String)              { m.Key = value }
@@ -240,3 +291,4 @@ func modelSetKRACKWorkaround(m *model, value types.Bool)    { m.KRACKWorkaround 
 func modelSetMode(m *model, value types.String)             { m.Mode = value }
 func modelSetNetwork(m *model, value types.String)          { m.Network = value }
 func modelSetSSID(m *model, value types.String)             { m.SSID = value }
+func modelSetWPAGroupRekey(m *model, value types.Int64)     { m.WPAGroupRekey = value }

--- a/openwrt/wireless/wifiiface/wifi_iface_acceptance_test.go
+++ b/openwrt/wireless/wifiiface/wifi_iface_acceptance_test.go
@@ -97,12 +97,14 @@ resource "openwrt_wireless_wifi_iface" "testing" {
 resource "openwrt_wireless_wifi_iface" "testing" {
 	device = "device-testing"
 	encryption = "sae"
+	ieee80211w = 1
 	id = "testing"
 	key = "password"
 	mode = "ap"
 	network = "network-testing"
 	ssid = "ssid-testing"
 	wpa_disable_eapol_key_retries = true
+	wpa_group_rekey = 3600
 }
 `,
 			providerBlock,
@@ -111,11 +113,13 @@ resource "openwrt_wireless_wifi_iface" "testing" {
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "id", "testing"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "device", "device-testing"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "encryption", "sae"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "ieee80211w", "1"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "key", "password"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "mode", "ap"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "network", "network-testing"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "ssid", "ssid-testing"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "wpa_disable_eapol_key_retries", "true"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "wpa_group_rekey", "3600"),
 		),
 	}
 


### PR DESCRIPTION
## Summary
- add `ieee80211w` and `wpa_group_rekey` support to `openwrt_wireless_wifi_iface`
- cover the new attributes in the wifi-iface acceptance test and regenerate the generated docs
- update the acceptance test image to the maintained `openwrt/rootfs` base and keep the container alive for health checks

## Test plan
- [x] `make docs`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `TF_ACC=1 go test -tags=acceptance.test ./openwrt/wireless/wifiiface -count=1`