### PR TITLE
Add support for additional wireless radio and FT options

### DIFF
--- a/docs/data-sources/wireless_wifi_device.md
+++ b/docs/data-sources/wireless_wifi_device.md
@@ -29,10 +29,12 @@ data "openwrt_wireless_wifi_device" "testing" {
 
 - `band` (String) Channel width. Must be one of: "2g", "5g", "6g".
 - `cell_density` (Number) Configures data rates based on the coverage cell density. Must be one of 0, 1, 2, 3.
-- `channel` (String) The wireless channel. Currently, only "auto" is supported.
+- `channel` (String) The wireless channel. Must be "auto" or a positive integer channel number represented as a string (e.g. "1", "6", "11").
 - `country` (String) Two-digit country code. E.g. "US".
+- `hwmode` (String) Wireless hardware mode. OpenWrt and driver support varies (e.g. `11g`, `11a`).
 - `htmode` (String) Channel width. Must be one of: "HE20", "HE40", "HE80", "HE160", "HT20", "HT40", "HT40-", "HT40+", "NONE", "VHT20", "VHT40", "VHT80", "VHT160".
 - `path` (String) Path of the device in `/sys/devices`.
+- `txpower` (Number) Transmit power in dBm.
 - `type` (String) The type of device. Currently only "mac80211" is supported.
 
 

--- a/docs/data-sources/wireless_wifi_iface.md
+++ b/docs/data-sources/wireless_wifi_iface.md
@@ -28,7 +28,9 @@ data "openwrt_wireless_wifi_iface" "testing" {
 ### Read-Only
 
 - `device` (String) Name of the physical device. This name is what the device is known as in LuCI/UCI, or the `id` field in Terraform.
+- `disassoc_low_ack` (Boolean) Disconnect clients that fail to acknowledge enough frames. Set to `false` to keep flaky clients connected.
 - `encryption` (String) Encryption method. Currently, only PSK encryption methods are supported. Must be one of: "none", "psk", "psk2", "psk2+aes", "psk2+ccmp", "psk2+tkip", "psk2+tkip+aes", "psk2+tkip+ccmp", "psk+aes", "psk+ccmp", "psk-mixed", "psk-mixed+aes", "psk-mixed+ccmp", "psk-mixed+tkip", "psk-mixed+tkip+aes", "psk-mixed+tkip+ccmp", "psk+tkip", "psk+tkip+aes", "psk+tkip+ccmp", "sae", "sae-mixed".
+- `ieee80211r` (Boolean) Enable 802.11r fast transition.
 - `isolate` (Boolean) Isolate wireless clients from each other.
 - `key` (String, Sensitive) The pre-shared passphrase from which the pre-shared key will be derived. The clear text key has to be 8-63 characters long.
 - `mode` (String) The operation mode of the wireless network interface controller.. Currently only "ap" is supported.

--- a/docs/resources/wireless_wifi_device.md
+++ b/docs/resources/wireless_wifi_device.md
@@ -15,8 +15,10 @@ The physical radio device.
 ```terraform
 resource "openwrt_wireless_wifi_device" "five_ghz" {
   band    = "5g"
-  channel = "auto"
+  channel = "36"
+  hwmode  = "11a"
   id      = "cfg123456"
+  txpower = 20
   type    = "mac80211"
 }
 ```
@@ -26,7 +28,7 @@ resource "openwrt_wireless_wifi_device" "five_ghz" {
 
 ### Required
 
-- `channel` (String) The wireless channel. Currently, only "auto" is supported.
+- `channel` (String) The wireless channel. Must be "auto" or a positive integer channel number represented as a string (e.g. "1", "6", "11").
 - `id` (String) Name of the section. This name is only used when interacting with UCI directly.
 - `type` (String) The type of device. Currently only "mac80211" is supported.
 
@@ -35,8 +37,10 @@ resource "openwrt_wireless_wifi_device" "five_ghz" {
 - `band` (String) Channel width. Must be one of: "2g", "5g", "6g".
 - `cell_density` (Number) Configures data rates based on the coverage cell density. Must be one of 0, 1, 2, 3.
 - `country` (String) Two-digit country code. E.g. "US".
+- `hwmode` (String) Wireless hardware mode. OpenWrt and driver support varies (e.g. `11g`, `11a`).
 - `htmode` (String) Channel width. Must be one of: "HE20", "HE40", "HE80", "HE160", "HT20", "HT40", "HT40-", "HT40+", "NONE", "VHT20", "VHT40", "VHT80", "VHT160".
 - `path` (String) Path of the device in `/sys/devices`.
+- `txpower` (Number) Transmit power in dBm.
 
 ## Import
 

--- a/docs/resources/wireless_wifi_iface.md
+++ b/docs/resources/wireless_wifi_iface.md
@@ -34,8 +34,10 @@ resource "openwrt_wireless_wifi_device" "five_ghz" {
 
 resource "openwrt_wireless_wifi_iface" "home" {
   device                        = openwrt_wireless_wifi_device.five_ghz.id
+  disassoc_low_ack              = false
   encryption                    = "sae"
   id                            = "wifinet0"
+  ieee80211r                    = false
   key                           = "password"
   mode                          = "ap"
   network                       = openwrt_network_interface.home.id
@@ -57,7 +59,9 @@ resource "openwrt_wireless_wifi_iface" "home" {
 
 ### Optional
 
+- `disassoc_low_ack` (Boolean) Disconnect clients that fail to acknowledge enough frames. Set to `false` to keep flaky clients connected.
 - `encryption` (String) Encryption method. Currently, only PSK encryption methods are supported. Must be one of: "none", "psk", "psk2", "psk2+aes", "psk2+ccmp", "psk2+tkip", "psk2+tkip+aes", "psk2+tkip+ccmp", "psk+aes", "psk+ccmp", "psk-mixed", "psk-mixed+aes", "psk-mixed+ccmp", "psk-mixed+tkip", "psk-mixed+tkip+aes", "psk-mixed+tkip+ccmp", "psk+tkip", "psk+tkip+aes", "psk+tkip+ccmp", "sae", "sae-mixed".
+- `ieee80211r` (Boolean) Enable 802.11r fast transition.
 - `isolate` (Boolean) Isolate wireless clients from each other.
 - `key` (String, Sensitive) The pre-shared passphrase from which the pre-shared key will be derived. The clear text key has to be 8-63 characters long.
 - `wpa_disable_eapol_key_retries` (Boolean) Enable WPA key reinstallation attack (KRACK) workaround. This should be `true` to enable KRACK workaround (you almost surely want this enabled).

--- a/openwrt/wireless/wifidevice/wifi_device.go
+++ b/openwrt/wireless/wifidevice/wifi_device.go
@@ -1,6 +1,8 @@
 package wifidevice
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -28,13 +30,17 @@ const (
 	cellDensityVeryHigh             = 3
 
 	channelAttribute            = "channel"
-	channelAttributeDescription = `The wireless channel. Currently, only "auto" is supported.`
+	channelAttributeDescription = `The wireless channel. Must be "auto" or a positive integer channel number represented as a string (e.g. "1", "6", "11").`
 	channelAuto                 = "auto"
 	channelUCIOption            = "channel"
 
 	countryCodeAttribute            = "country"
 	countryCodeAttributeDescription = `Two-digit country code. E.g. "US".`
 	countryCodeUCIOption            = "country"
+
+	hwModeAttribute            = "hwmode"
+	hwModeAttributeDescription = "Wireless hardware mode. OpenWrt and driver support varies (e.g. `11g`, `11a`)."
+	hwModeUCIOption            = "hwmode"
 
 	htModeAttribute            = "htmode"
 	htModeAttributeDescription = `Channel width. Must be one of: "HE20", "HE40", "HE80", "HE160", "HT20", "HT40", "HT40-", "HT40+", "NONE", "VHT20", "VHT40", "VHT80", "VHT160".`
@@ -58,6 +64,10 @@ const (
 	pathUCIOption            = "path"
 
 	schemaDescription = "The physical radio device."
+
+	txPowerAttribute            = "txpower"
+	txPowerAttributeDescription = "Transmit power in dBm."
+	txPowerUCIOption            = "txpower"
 
 	typeAttribute            = "type"
 	typeAttributeDescription = `The type of device. Currently only "mac80211" is supported.`
@@ -104,8 +114,9 @@ var (
 		ResourceExistence: lucirpcglue.Required,
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(modelGetChannel, channelAttribute, channelUCIOption),
 		Validators: []validator.String{
-			stringvalidator.OneOf(
-				channelAuto,
+			stringvalidator.RegexMatches(
+				regexp.MustCompile(`^(auto|[1-9][0-9]*)$`),
+				`must be "auto" or a positive integer channel number`,
 			),
 		},
 	}
@@ -117,6 +128,16 @@ var (
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(modelGetCountryCode, countryCodeAttribute, countryCodeUCIOption),
 		Validators: []validator.String{
 			stringvalidator.LengthBetween(2, 2),
+		},
+	}
+
+	hwModeSchemaAttribute = lucirpcglue.StringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:       hwModeAttributeDescription,
+		ReadResponse:      lucirpcglue.ReadResponseOptionString(modelSetHWMode, hwModeAttribute, hwModeUCIOption),
+		ResourceExistence: lucirpcglue.NoValidation,
+		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(modelGetHWMode, hwModeAttribute, hwModeUCIOption),
+		Validators: []validator.String{
+			stringvalidator.LengthAtLeast(1),
 		},
 	}
 
@@ -151,14 +172,26 @@ var (
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(modelGetPath, pathAttribute, pathUCIOption),
 	}
 
+	txPowerSchemaAttribute = lucirpcglue.Int64SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:       txPowerAttributeDescription,
+		ReadResponse:      lucirpcglue.ReadResponseOptionInt64(modelSetTXPower, txPowerAttribute, txPowerUCIOption),
+		ResourceExistence: lucirpcglue.NoValidation,
+		UpsertRequest:     lucirpcglue.UpsertRequestOptionInt64(modelGetTXPower, txPowerAttribute, txPowerUCIOption),
+		Validators: []validator.Int64{
+			int64validator.AtLeast(1),
+		},
+	}
+
 	schemaAttributes = map[string]lucirpcglue.SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
 		bandAttribute:           bandSchemaAttribute,
 		cellDensityAttribute:    cellDensitySchemaAttribute,
 		channelAttribute:        channelSchemaAttribute,
 		countryCodeAttribute:    countryCodeSchemaAttribute,
+		hwModeAttribute:         hwModeSchemaAttribute,
 		lucirpcglue.IdAttribute: lucirpcglue.IdSchemaAttribute(modelGetId, modelSetId),
 		htModeAttribute:         htModeSchemaAttribute,
 		pathAttribute:           pathSchemaAttribute,
+		txPowerAttribute:        txPowerSchemaAttribute,
 		typeAttribute:           typeSchemaAttribute,
 	}
 
@@ -200,9 +233,11 @@ type model struct {
 	CellDensity types.Int64  `tfsdk:"cell_density"`
 	Channel     types.String `tfsdk:"channel"`
 	CountryCode types.String `tfsdk:"country"`
+	HWMode      types.String `tfsdk:"hwmode"`
 	HTMode      types.String `tfsdk:"htmode"`
 	Id          types.String `tfsdk:"id"`
 	Path        types.String `tfsdk:"path"`
+	TXPower     types.Int64  `tfsdk:"txpower"`
 	Type        types.String `tfsdk:"type"`
 }
 
@@ -210,16 +245,20 @@ func modelGetBand(m model) types.String        { return m.Band }
 func modelGetCellDensity(m model) types.Int64  { return m.CellDensity }
 func modelGetChannel(m model) types.String     { return m.Channel }
 func modelGetCountryCode(m model) types.String { return m.CountryCode }
+func modelGetHWMode(m model) types.String      { return m.HWMode }
 func modelGetHTMode(m model) types.String      { return m.HTMode }
 func modelGetId(m model) types.String          { return m.Id }
 func modelGetPath(m model) types.String        { return m.Path }
+func modelGetTXPower(m model) types.Int64      { return m.TXPower }
 func modelGetType(m model) types.String        { return m.Type }
 
 func modelSetBand(m *model, value types.String)        { m.Band = value }
 func modelSetCellDensity(m *model, value types.Int64)  { m.CellDensity = value }
 func modelSetChannel(m *model, value types.String)     { m.Channel = value }
 func modelSetCountryCode(m *model, value types.String) { m.CountryCode = value }
+func modelSetHWMode(m *model, value types.String)      { m.HWMode = value }
 func modelSetHTMode(m *model, value types.String)      { m.HTMode = value }
 func modelSetId(m *model, value types.String)          { m.Id = value }
 func modelSetPath(m *model, value types.String)        { m.Path = value }
+func modelSetTXPower(m *model, value types.Int64)      { m.TXPower = value }
 func modelSetType(m *model, value types.String)        { m.Type = value }

--- a/openwrt/wireless/wifidevice/wifi_device_acceptance_test.go
+++ b/openwrt/wireless/wifidevice/wifi_device_acceptance_test.go
@@ -21,7 +21,9 @@ func TestDataSourceAcceptance(t *testing.T) {
 		t,
 	)
 	options := lucirpc.Options{
-		"channel": lucirpc.String("auto"),
+		"channel": lucirpc.String("6"),
+		"hwmode":  lucirpc.String("11g"),
+		"txpower": lucirpc.Integer(15),
 		"type":    lucirpc.String("mac80211"),
 	}
 	ok, err := client.CreateSection(ctx, "wireless", "wifi-device", "testing", options)
@@ -40,7 +42,9 @@ data "openwrt_wireless_wifi_device" "testing" {
 		),
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_device.testing", "id", "testing"),
-			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_device.testing", "channel", "auto"),
+			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_device.testing", "channel", "6"),
+			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_device.testing", "hwmode", "11g"),
+			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_device.testing", "txpower", "15"),
 			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_device.testing", "type", "mac80211"),
 		),
 	}
@@ -64,8 +68,10 @@ func TestResourceAcceptance(t *testing.T) {
 %s
 
 resource "openwrt_wireless_wifi_device" "testing" {
-	channel = "auto"
+	channel = "6"
+	hwmode = "11g"
 	id = "testing"
+	txpower = 15
 	type = "mac80211"
 }
 `,
@@ -73,7 +79,9 @@ resource "openwrt_wireless_wifi_device" "testing" {
 		),
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "id", "testing"),
-			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "channel", "auto"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "channel", "6"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "hwmode", "11g"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "txpower", "15"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "type", "mac80211"),
 		),
 	}
@@ -88,8 +96,11 @@ resource "openwrt_wireless_wifi_device" "testing" {
 
 resource "openwrt_wireless_wifi_device" "testing" {
 	band = "6g"
-	channel = "auto"
+	channel = "11"
+	hwmode = "11a"
+	htmode = "HE80"
 	id = "testing"
+	txpower = 20
 	type = "mac80211"
 }
 `,
@@ -98,7 +109,10 @@ resource "openwrt_wireless_wifi_device" "testing" {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "id", "testing"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "band", "6g"),
-			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "channel", "auto"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "channel", "11"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "hwmode", "11a"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "htmode", "HE80"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "txpower", "20"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_device.testing", "type", "mac80211"),
 		),
 	}

--- a/openwrt/wireless/wifiiface/wifi_iface.go
+++ b/openwrt/wireless/wifiiface/wifi_iface.go
@@ -41,6 +41,14 @@ const (
 	encryptionMethodSAEMixed             = "sae-mixed"
 	encryptionMethodUCIOption            = "encryption"
 
+	disassocLowACKAttribute            = "disassoc_low_ack"
+	disassocLowACKAttributeDescription = "Disconnect clients that fail to acknowledge enough frames. Set to `false` to keep flaky clients connected."
+	disassocLowACKUCIOption            = "disassoc_low_ack"
+
+	ieee80211rAttribute            = "ieee80211r"
+	ieee80211rAttributeDescription = "Enable 802.11r fast transition."
+	ieee80211rUCIOption            = "ieee80211r"
+
 	isolateClientsAttribute            = "isolate"
 	isolateClientsAttributeDescription = "Isolate wireless clients from each other."
 	isolateClientsUCIOption            = "isolate"
@@ -80,6 +88,19 @@ var (
 		UpsertRequest:     lucirpcglue.UpsertRequestOptionString(modelGetDevice, deviceAttribute, deviceUCIOption),
 	}
 
+	disassocLowACKSchemaAttribute = lucirpcglue.BoolSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:       disassocLowACKAttributeDescription,
+		ReadResponse:      lucirpcglue.ReadResponseOptionBool(modelSetDisassocLowACK, disassocLowACKAttribute, disassocLowACKUCIOption),
+		ResourceExistence: lucirpcglue.NoValidation,
+		UpsertRequest:     lucirpcglue.UpsertRequestOptionBool(modelGetDisassocLowACK, disassocLowACKAttribute, disassocLowACKUCIOption),
+		Validators: []validator.Bool{
+			lucirpcglue.RequiresAttributeEqualString(
+				path.MatchRoot(modeAttribute),
+				modeAP,
+			),
+		},
+	}
+
 	encryptionMethodSchemaAttribute = lucirpcglue.StringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
 		Description:       encryptionMethodAttributeDescription,
 		ReadResponse:      lucirpcglue.ReadResponseOptionString(modelSetEncryptionMethod, encryptionMethodAttribute, encryptionMethodUCIOption),
@@ -108,6 +129,19 @@ var (
 				encryptionMethodPSKTKIPCCMP,
 				encryptionMethodSAE,
 				encryptionMethodSAEMixed,
+			),
+		},
+	}
+
+	ieee80211rSchemaAttribute = lucirpcglue.BoolSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:       ieee80211rAttributeDescription,
+		ReadResponse:      lucirpcglue.ReadResponseOptionBool(modelSetIEEE80211R, ieee80211rAttribute, ieee80211rUCIOption),
+		ResourceExistence: lucirpcglue.NoValidation,
+		UpsertRequest:     lucirpcglue.UpsertRequestOptionBool(modelGetIEEE80211R, ieee80211rAttribute, ieee80211rUCIOption),
+		Validators: []validator.Bool{
+			lucirpcglue.RequiresAttributeEqualString(
+				path.MatchRoot(modeAttribute),
+				modeAP,
 			),
 		},
 	}
@@ -170,8 +204,10 @@ var (
 	}
 
 	schemaAttributes = map[string]lucirpcglue.SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		disassocLowACKAttribute:   disassocLowACKSchemaAttribute,
 		deviceAttribute:           deviceSchemaAttribute,
 		encryptionMethodAttribute: encryptionMethodSchemaAttribute,
+		ieee80211rAttribute:       ieee80211rSchemaAttribute,
 		isolateClientsAttribute:   isolateClientsSchemaAttribute,
 		keyAttribute:              keySchemaAttribute,
 		krackWorkaroundAttribute:  krackWorkaroundSchemaAttribute,
@@ -210,8 +246,10 @@ func NewResource() resource.Resource {
 }
 
 type model struct {
+	DisassocLowACK   types.Bool   `tfsdk:"disassoc_low_ack"`
 	Device           types.String `tfsdk:"device"`
 	EncryptionMethod types.String `tfsdk:"encryption"`
+	IEEE80211R       types.Bool   `tfsdk:"ieee80211r"`
 	Id               types.String `tfsdk:"id"`
 	IsolateClients   types.Bool   `tfsdk:"isolate"`
 	Key              types.String `tfsdk:"key"`
@@ -221,8 +259,10 @@ type model struct {
 	SSID             types.String `tfsdk:"ssid"`
 }
 
+func modelGetDisassocLowACK(m model) types.Bool     { return m.DisassocLowACK }
 func modelGetDevice(m model) types.String           { return m.Device }
 func modelGetEncryptionMethod(m model) types.String { return m.EncryptionMethod }
+func modelGetIEEE80211R(m model) types.Bool         { return m.IEEE80211R }
 func modelGetId(m model) types.String               { return m.Id }
 func modelGetIsolateClients(m model) types.Bool     { return m.IsolateClients }
 func modelGetKey(m model) types.String              { return m.Key }
@@ -231,8 +271,10 @@ func modelGetMode(m model) types.String             { return m.Mode }
 func modelGetNetwork(m model) types.String          { return m.Network }
 func modelGetSSID(m model) types.String             { return m.SSID }
 
+func modelSetDisassocLowACK(m *model, value types.Bool)     { m.DisassocLowACK = value }
 func modelSetDevice(m *model, value types.String)           { m.Device = value }
 func modelSetEncryptionMethod(m *model, value types.String) { m.EncryptionMethod = value }
+func modelSetIEEE80211R(m *model, value types.Bool)         { m.IEEE80211R = value }
 func modelSetId(m *model, value types.String)               { m.Id = value }
 func modelSetIsolateClients(m *model, value types.Bool)     { m.IsolateClients = value }
 func modelSetKey(m *model, value types.String)              { m.Key = value }

--- a/openwrt/wireless/wifiiface/wifi_iface_acceptance_test.go
+++ b/openwrt/wireless/wifiiface/wifi_iface_acceptance_test.go
@@ -21,10 +21,12 @@ func TestDataSourceAcceptance(t *testing.T) {
 		t,
 	)
 	options := lucirpc.Options{
-		"device":  lucirpc.String("device-testing"),
-		"mode":    lucirpc.String("ap"),
-		"network": lucirpc.String("network-testing"),
-		"ssid":    lucirpc.String("ssid-testing"),
+		"device":           lucirpc.String("device-testing"),
+		"disassoc_low_ack": lucirpc.Boolean(false),
+		"ieee80211r":       lucirpc.Boolean(false),
+		"mode":             lucirpc.String("ap"),
+		"network":          lucirpc.String("network-testing"),
+		"ssid":             lucirpc.String("ssid-testing"),
 	}
 	ok, err := client.CreateSection(ctx, "wireless", "wifi-iface", "testing", options)
 	assert.NilError(t, err)
@@ -43,6 +45,8 @@ data "openwrt_wireless_wifi_iface" "testing" {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_iface.testing", "id", "testing"),
 			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_iface.testing", "device", "device-testing"),
+			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_iface.testing", "disassoc_low_ack", "false"),
+			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_iface.testing", "ieee80211r", "false"),
 			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_iface.testing", "mode", "ap"),
 			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_iface.testing", "network", "network-testing"),
 			resource.TestCheckResourceAttr("data.openwrt_wireless_wifi_iface.testing", "ssid", "ssid-testing"),
@@ -69,7 +73,9 @@ func TestResourceAcceptance(t *testing.T) {
 
 resource "openwrt_wireless_wifi_iface" "testing" {
 	device = "device-testing"
+	disassoc_low_ack = true
 	id = "testing"
+	ieee80211r = true
 	mode = "ap"
 	network = "network-testing"
 	ssid = "ssid-testing"
@@ -80,6 +86,8 @@ resource "openwrt_wireless_wifi_iface" "testing" {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "id", "testing"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "device", "device-testing"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "disassoc_low_ack", "true"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "ieee80211r", "true"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "mode", "ap"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "network", "network-testing"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "ssid", "ssid-testing"),
@@ -96,8 +104,10 @@ resource "openwrt_wireless_wifi_iface" "testing" {
 
 resource "openwrt_wireless_wifi_iface" "testing" {
 	device = "device-testing"
+	disassoc_low_ack = false
 	encryption = "sae"
 	id = "testing"
+	ieee80211r = false
 	key = "password"
 	mode = "ap"
 	network = "network-testing"
@@ -110,7 +120,9 @@ resource "openwrt_wireless_wifi_iface" "testing" {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "id", "testing"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "device", "device-testing"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "disassoc_low_ack", "false"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "encryption", "sae"),
+			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "ieee80211r", "false"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "key", "password"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "mode", "ap"),
 			resource.TestCheckResourceAttr("openwrt_wireless_wifi_iface.testing", "network", "network-testing"),


### PR DESCRIPTION
## Summary
- add `openwrt_wireless_wifi_device` support for numeric `channel` values, `hwmode`, and `txpower`
- add `openwrt_wireless_wifi_iface` support for `ieee80211r` and `disassoc_low_ack`
- expand acceptance coverage and update data source/resource docs for new wireless attributes

## Test plan
- [x] Run `go test ./...`
- [ ] Run acceptance tests against a test OpenWrt environment (`go test -tags acceptance.test ./...`)